### PR TITLE
Tests: add benchmarking for integers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,9 @@ endif()
 
 
 if(BUILD_TESTING)
+
   if(YARP_TELEMETRY_USES_SYSTEM_Catch2)
-    find_package(Catch2 REQUIRED)
+    find_package(Catch2 2.13.1 REQUIRED)
   else()
     include(FetchContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ option(YARP_TELEMETRY_USES_SYSTEM_Catch2 OFF)
 cmake_dependent_option(YARP_VALGRIND_TESTS
                        "Run YARP tests under Valgrind" OFF
                        "BUILD_TESTING" OFF)
+cmake_dependent_option(ENABLE_BENCHMARKING
+                       "Enable the benchmarking in the unit tests" OFF
+                       "BUILD_TESTING" OFF)
 mark_as_advanced(YARP_VALGRIND_TESTS)
 
 if(YARP_VALGRIND_TESTS)

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -13,6 +13,7 @@
 #include <yarp/os/Time.h>
 #include <catch2/catch.hpp>
 #include <vector>
+#include <mutex>
 
 constexpr size_t n_samples{ 3 };
 
@@ -255,4 +256,140 @@ TEST_CASE("Buffer Manager Test")
 
     }
 
+#if defined CATCH_CONFIG_ENABLE_BENCHMARKING
+
+    SECTION("Benchmarking section scalar int") {
+        yarp::telemetry::experimental::BufferConfig bufferConfig;
+        yarp::telemetry::experimental::ChannelInfo var_one{ "one", {1,1} };
+        bufferConfig.channels.push_back(var_one);
+        bufferConfig.filename = "buffer_manager_test_scalar_benchmark";
+
+        bufferConfig.n_samples = 1000;
+        BENCHMARK_ADVANCED("BufferOfInt-1000Samples-oneVariable-1x1")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+        bufferConfig.n_samples = 10000;
+        BENCHMARK_ADVANCED("BufferOfInt-10000Samples-oneVariable-1x1")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+
+        bufferConfig.n_samples = 100000;
+        BENCHMARK_ADVANCED("BufferOfInt-100000Samples-oneVariable-1x1")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+
+    }
+    SECTION("Benchmarking section vector int") {
+
+        yarp::telemetry::experimental::BufferConfig bufferConfig;
+        yarp::telemetry::experimental::ChannelInfo var_one{ "one", {3,1} };
+        bufferConfig.channels.push_back(var_one);
+        bufferConfig.filename = "buffer_manager_test_vector_benchmark";
+
+
+        bufferConfig.n_samples = 1000;
+        BENCHMARK_ADVANCED("BufferOfInt-1000Samples-oneVariable-3x1")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i, i + 1, i + 2 }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+
+        bufferConfig.n_samples = 10000;
+        BENCHMARK_ADVANCED("BufferOfInt-10000Samples-oneVariable-3x1")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i, i + 1, i + 2 }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+
+        bufferConfig.n_samples = 100000;
+        BENCHMARK_ADVANCED("BufferOfInt-100000Samples-oneVariable-3x1")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i, i + 1, i + 2 }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+
+    }
+
+
+    SECTION("Benchmarking section matrix int") {
+
+        yarp::telemetry::experimental::BufferConfig bufferConfig;
+        yarp::telemetry::experimental::ChannelInfo var_one{ "one", {3,2} };
+        bufferConfig.channels.push_back(var_one);
+        bufferConfig.filename = "buffer_manager_test_matrix_benchmark";
+
+
+        bufferConfig.n_samples = 1000;
+        BENCHMARK_ADVANCED("BufferOfInt-1000Samples-oneVariable-3x2")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i, i + 1, i + 2, i + 3, i + 4, i + 5 }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+
+        bufferConfig.n_samples = 10000;
+        BENCHMARK_ADVANCED("BufferOfInt-10000Samples-oneVariable-3x2")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i, i + 1, i + 2, i + 3, i + 4, i + 5 }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+
+        bufferConfig.n_samples = 100000;
+        BENCHMARK_ADVANCED("BufferOfInt-100000Samples-oneVariable-3x2")(Catch::Benchmark::Chronometer meter) {
+            yarp::telemetry::experimental::BufferManager<int32_t> bm;
+            bm.configure(bufferConfig);
+
+            for (int i = 0; i < bufferConfig.n_samples; i++) {
+                bm.push_back({ i, i + 1, i + 2, i + 3, i + 4, i + 5 }, "one");
+            }
+            // measure
+            meter.measure([&bm] { return bm.saveToFile(); });
+        };
+    }
+#endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,9 +9,12 @@ if(YARP_VALGRIND_TESTS)
 endif()
 
 add_executable(bufferManager_test BufferManagerTest.cpp)
+if(ENABLE_BENCHMARKING)
+  target_compile_definitions(bufferManager_test PRIVATE -DCATCH_CONFIG_ENABLE_BENCHMARKING)
+endif()
 target_link_libraries(bufferManager_test PRIVATE Catch2::Catch2
-                                                 matioCpp::matioCpp 
-                                                 Boost::boost 
+                                                 matioCpp::matioCpp
+                                                 Boost::boost
                                                  YARP::YARP_telemetry
                                                  YARP::YARP_conf
                                                  YARP::YARP_os


### PR DESCRIPTION
Added the benchmarking section in `BufferManagerTest`.

It can be enable with `ENABLE_BENCHMARKING` cmake option.

TODO: remove https://github.com/robotology/yarp-telemetry/pull/121/commits/41e53d06239735337c338c22209a68539f9541c1 before merging, it has been added because the messages printed ruin the format of the benchmarking

It fixes #116 

cc @S-Dafarra @drdanz 