### PR TITLE
BufferManager: add zlib compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added the possibility to specify the time of a ``Record`` with ``push_back``.
+- Added the possibility to enable the zlib compression.
+- Fixed yarp-telemetry.ini generation.
+- Fixed load of `telemetryDeviceDumper` plugin.
 
 ## [0.1.0] - 2021-04-02
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set(CMAKE_CXX_FLAGS ${YARP_CXX_FLAGS})
 
 
 #### INSERT find_package(MATIO) and other libraries here
-find_package(matioCpp REQUIRED)
+find_package(matioCpp 0.1.1 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is the telemetry component for YARP.
 ### Conda packages
 
 It is possible to install on `linux`, `macOS` and `Windows` via [conda](https://anaconda.org/robotology/yarp-telemetry), just running:
-```bash 
+```bash
 conda install -c robotology yarp-telemetry
 ```
 
@@ -33,7 +33,7 @@ The depencies are:
 - [CMake](https://cmake.org/install/) (minimum version 3.12)
 - [Boost](https://www.boost.org/)
 - [YARP](https://www.yarp.it/git-master/install.html) (minimum version 3.4.0)
-- [matio-cpp](https://github.com/dic-iit/matio-cpp#installation)
+- [matio-cpp](https://github.com/dic-iit/matio-cpp#installation) (minimum version 0.1.1)
 - [nlohmann_json](https://github.com/nlohmann/json#integration) (minimum version 3.9.2 - not yet released)
 - [Catch2](https://github.com/catchorg/Catch2.git) (v2.13.1, for the unit tests)
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ Where the file has to have this format:
     "channels": [
         ["one",[1,1]],
         ["two",[1,1]]
-    ]
+    ],
+    "enable_compression": true
 }
 ```
 The configuration can be saved **to a json file**

--- a/src/examples/conf/test_json.json
+++ b/src/examples/conf/test_json.json
@@ -11,5 +11,6 @@
     "channels": [
         ["one",[1,1]],
         ["two",[1,1]]
-    ]
+    ],
+    "enable_compression": true
 }

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.cpp
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.cpp
@@ -13,7 +13,7 @@
 
 namespace yarp::telemetry::experimental {
     // This expects that the name of the json keyword is the same of the relative variable
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, description_list, path, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels)
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, description_list, path, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels, enable_compression)
 }
 bool bufferConfigFromJson(yarp::telemetry::experimental::BufferConfig& bufferConfig, const std::string& config_filename) {
     // read a JSON file

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
@@ -20,6 +20,7 @@ using dimensions_t = std::vector<size_t>;
  * name and dimensions.
  */
 using ChannelInfo = std::pair< std::string, dimensions_t >;
+
 /**
  * @brief Struct containing the parameters for configuring a yarp::telemetry::experimental::BufferManager.
  *
@@ -34,6 +35,7 @@ struct YARP_telemetry_API BufferConfig {
     bool auto_save{ false };/**< the flag for enabling the save in the destructor of the yarp::telemetry::experimental::BufferManager */
     bool save_periodically{ false };/**< the flag for enabling the periodic save thread. */
     std::vector<ChannelInfo> channels;/**< the list of pairs representing the channels(variables) */
+    bool enable_compression{ false }; /**< the flag for enabling the zlib compression */
 };
 
 } // yarp::telemetry::experimental

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
@@ -169,6 +169,16 @@ public:
     }
 
     /**
+    * @brief Enable the zlib compression.
+    *
+    * @param[in] flag for enabling/disabling compression.
+    */
+    void enableCompression(bool enable_compression) {
+        m_bufferConfig.enable_compression = enable_compression;
+        return;
+    }
+
+    /**
      * @brief Set the description list that will be saved in all the files.
      *
      * @param[in] description The description to be set.
@@ -384,7 +394,7 @@ public:
             new_file = m_bufferConfig.path + new_file;
         }
         matioCpp::File file = matioCpp::File::Create(new_file);
-        return file.write(timeSeries, matioCpp::Compression::zlib);
+        return file.write(timeSeries, m_bufferConfig.enable_compression ? matioCpp::Compression::zlib : matioCpp::Compression::None);
     }
 
     /**

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
@@ -384,7 +384,7 @@ public:
             new_file = m_bufferConfig.path + new_file;
         }
         matioCpp::File file = matioCpp::File::Create(new_file);
-        return file.write(timeSeries);
+        return file.write(timeSeries, matioCpp::Compression::zlib);
     }
 
     /**

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -134,6 +134,7 @@ TEST_CASE("Buffer Manager Test")
         bufferConfig.save_period = 1.0;
         bufferConfig.data_threshold = 10;
         bufferConfig.save_periodically = true;
+        bufferConfig.enable_compression = true;
 
         REQUIRE(bufferConfigToJson(bufferConfig, "test_json_write.json"));
 
@@ -153,6 +154,7 @@ TEST_CASE("Buffer Manager Test")
         REQUIRE(bufferConfig.channels[0].second == std::vector<size_t>{1, 1});
         REQUIRE(bufferConfig.channels[1].first == "two");
         REQUIRE(bufferConfig.channels[1].second == std::vector<size_t>{1, 1});
+        REQUIRE(bufferConfig.enable_compression == true);
 
         REQUIRE(bm.configure(bufferConfig));
 
@@ -212,6 +214,7 @@ TEST_CASE("Buffer Manager Test")
         bufferConfig.save_periodically = true;
         bufferConfig.auto_save = true;
         bufferConfig.save_period = 3600; // Save every hour.
+        bufferConfig.enable_compression = true;
 
         // This will set_capacity the buffers
         REQUIRE(bm.configure(bufferConfig));


### PR DESCRIPTION
This requires `matioCpp v0.1.1`.

To be merged after #121 

It fixes #115 