### PR TITLE
telemetryDeviceDumper: added all the controlBoardDumper interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the possibility to enable the zlib compression.
 - Fixed yarp-telemetry.ini generation.
 - Fixed load of `telemetryDeviceDumper` plugin.
+- Added the log from these interfaces in the `telemetryDeviceDumper`:
+  - `yarp::dev::IMotorEncoders`
+  - `yarp::dev::IPidControl`
+  - `yarp::dev::IAmplifierControl`
+  - `yarp::dev::IControlMode`
+  - `yarp::dev::IInteractionMode`
+  - `yarp::dev::ITorqueControl`
+  - `yarp::dev::IMultipleWrapper`
 
 ## [0.1.0] - 2021-04-02
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_de
 | `logJointVelocity`  (DEPRECATED)   | bool     | -     | false     | No     | Enable the log of joint velocities.     |
 | `logJointAcceleration` (DEPRECATED)   | bool     | -     | false     | No     | Enable the log of joint accelerations.     |
 | `logIEncoders`     | bool     | -     |  true | No     | Enable the log of `encoders`, `velocity` and `acceleration` (http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html)     |
-| `logIToequeControl`     | bool     | -     | false     | No     | Enable the log of `torque`(http://yarp.it/git-master/classyarp_1_1dev_1_1ITorqueControl.html).     |
+| `logITorqueControl`     | bool     | -     | false     | No     | Enable the log of `torque`(http://yarp.it/git-master/classyarp_1_1dev_1_1ITorqueControl.html).     |
 | `logIMotorEncoders`     | bool     | -     | false     | No     | Enable the log of `motor_encoders`, `motor_velocity` and `motor_acceleration` (http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html).     |
 | `logIControlMode`     | bool     | -     | false     | No     | Enable the log of `control_mode` (http://yarp.it/git-master/classyarp_1_1dev_1_1IControlMode.html.     |
 | `logIInteractionlMode`     | bool     | -     | false     | No     | Enable the log of `interaction_modes` (http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html.     |
@@ -300,7 +300,22 @@ The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_de
 | `data_threshold`     | size_t     | -     | 0     | No     | The save thread saves to a file if there are at least `data_threshold` samples     |
 | `auto_save`     | bool     | -     | false     | No(but it has to be set to true if `save_periodically` is set to false)     | the flag for enabling the save in the destructor of the `yarp::telemetry::experimental::BufferManager`     |
 
+### Mapping .mat variables -> YARP interfaces
 
+| Variable name        | YARP interface |
+| -------------------- | -------------- |
+| `encoders`           | http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#abcfe10041280b99c7c4384c4fd93a9dd |
+| `velocity`           | http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#ac84ae2f65f4a93b66827a3a424d1f743 |
+| `acceleration`       | http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#a3bcb5fe5c6a5e15e57f4723bbe12c57a |
+| `motor_encoders`     | http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#ac02fb05bb3e9ac9a381d41b59c38c412 |
+| `motor_velocity`     | http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#a4624348cc129bfeb12ad0e6d2892b76c |
+| `motor_acceleration` | http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#a9394d8b5cc4f3d58aeaa07c3fb9a6e6a |
+| `control_mode`       | http://yarp.it/git-master/classyarp_1_1dev_1_1IControlMode.html#a32f04715873a8099ec40671f65faff8d |
+| `interaction_mode`   | http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html#a6055ce20216f479da6c63807a4d11f54 |
+| `position_error`     | http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28 |
+| `position_reference` | http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da |
+| `torque_error`       | http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28 |
+| `torque_reference`   | http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da |
 
 ### Example of xml
 

--- a/README.md
+++ b/README.md
@@ -277,12 +277,19 @@ The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_de
 ### Parameters
 
 
-
 | Parameter name | Type | Units | Default | Required | Description |
 | -------- | -------- | -------- | -------- | -------- | -------- |
 | `axesNames`     | List of strings     | -  | -     | Yes     | The axes contained in the axesNames parameter are then mapped to the wrapped controlboard in the attachAll method, using controlBoardRemapper class. |
-| `logJointVelocity`     | bool     | -     | false     | No     | Enable the log of joint velocities.     |
-| `logJointAcceleration`     | bool     | -     | false     | No     | Enable the log of joint accelerations.     |
+| `logJointVelocity`  (DEPRECATED)   | bool     | -     | false     | No     | Enable the log of joint velocities.     |
+| `logJointAcceleration` (DEPRECATED)   | bool     | -     | false     | No     | Enable the log of joint accelerations.     |
+| `logIEncoders`     | bool     | -     |  true | No     | Enable the log of `encoders`, `velocity` and `acceleration` (http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html)     |
+| `logIToequeControl`     | bool     | -     | false     | No     | Enable the log of `torque`(http://yarp.it/git-master/classyarp_1_1dev_1_1ITorqueControl.html).     |
+| `logIMotorEncoders`     | bool     | -     | false     | No     | Enable the log of `motor_encoders`, `motor_velocity` and `motor_acceleration` (http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html).     |
+| `logIControlMode`     | bool     | -     | false     | No     | Enable the log of `control_mode` (http://yarp.it/git-master/classyarp_1_1dev_1_1IControlMode.html.     |
+| `logIInteractionlMode`     | bool     | -     | false     | No     | Enable the log of `interaction_modes` (http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html.     |
+| `logIPidControl`     | bool     | -     | false     | No     | Enable the log of `position_error`, `position_reference`, `torque_error`, `torque_reference`(http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html).|
+| `logIAmplifierControl`     | bool     | -     | false     | No     | Enable the log of `pwm` and `current` (http://yarp.it/git-master/classyarp_1_1dev_1_1IAmplifierControl.html).     |
+| `logAllQuantities`     | bool     | -     | false     | No     | Enable the log all quantities described above. |
 | `saveBufferManagerConfiguration`     | bool     | -    | false     | No     | Enable the save of the configuration of the BufferManager into `path`+ `"bufferConfig"` + `experimentName` + `".json"`     |
 | `json_file`     | string     | -     | -     | No     | Configure the `yarp::telemetry::experimental::BufferManager`s reading from a json file like [in Example configuration file](#example-configuration-file). Note that this configuration will overwrite the parameter-by-parameter configuration   |
 | `experimentName`     | string     | -     | -     | Yes     | Prefix of the files that will be saved. The files will be named: `experimentName`+`timestamp`+ `".mat"`.     |

--- a/README.md
+++ b/README.md
@@ -304,18 +304,18 @@ The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_de
 
 | Variable name        | YARP interface |
 | -------------------- | -------------- |
-| `encoders`           | http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#abcfe10041280b99c7c4384c4fd93a9dd |
-| `velocity`           | http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#ac84ae2f65f4a93b66827a3a424d1f743 |
-| `acceleration`       | http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#a3bcb5fe5c6a5e15e57f4723bbe12c57a |
-| `motor_encoders`     | http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#ac02fb05bb3e9ac9a381d41b59c38c412 |
-| `motor_velocity`     | http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#a4624348cc129bfeb12ad0e6d2892b76c |
-| `motor_acceleration` | http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#a9394d8b5cc4f3d58aeaa07c3fb9a6e6a |
-| `control_mode`       | http://yarp.it/git-master/classyarp_1_1dev_1_1IControlMode.html#a32f04715873a8099ec40671f65faff8d |
-| `interaction_mode`   | http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html#a6055ce20216f479da6c63807a4d11f54 |
-| `position_error`     | http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28 |
-| `position_reference` | http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da |
-| `torque_error`       | http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28 |
-| `torque_reference`   | http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da |
+| `encoders`           | [`yarp::dev::IEncoders::getEncoders`](http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#abcfe10041280b99c7c4384c4fd93a9dd) |
+| `velocity`           | [`yarp::dev::IEncoders::getEncoderSpeeds`](http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#ac84ae2f65f4a93b66827a3a424d1f743) |
+| `acceleration`       | [`yarp::dev::IEncoders::getEncoderAccelerations`](http://yarp.it/git-master/classyarp_1_1dev_1_1IEncoders.html#a3bcb5fe5c6a5e15e57f4723bbe12c57a) |
+| `motor_encoders`     | [`yarp::dev::IMotorEncoders::getMotorEncoders`](http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#ac02fb05bb3e9ac9a381d41b59c38c412) |
+| `motor_velocity`     | [`yarp::dev::IMotorEncoders::getMotorEncoderSpeeds`](http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#a4624348cc129bfeb12ad0e6d2892b76c) |
+| `motor_acceleration` | [`yarp::dev::IMotorEncoders::getMotorEncoderAccelerations`](http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html#a9394d8b5cc4f3d58aeaa07c3fb9a6e6a) |
+| `control_mode`       | [`yarp::dev::IControlMode::getControlModes`](http://yarp.it/git-master/classyarp_1_1dev_1_1IControlMode.html#a32f04715873a8099ec40671f65faff8d) |
+| `interaction_mode`   | [`yarp::dev::IInteractionMode::getInteractionModes`](http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html#a6055ce20216f479da6c63807a4d11f54) |
+| `position_error`     | [`yarp::dev::IPidControl::getPidErrors`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28) |
+| `position_reference` | [`yarp::dev::IPidControl::getPidReferences`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da) |
+| `torque_error`       | [`yarp::dev::IPidControl::getPidErrors`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28) |
+| `torque_reference`   | [`yarp::dev::IPidControl::getPidReferences`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da) |
 
 ### Example of xml
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_de
 | `logITorqueControl`     | bool     | -     | false     | No     | Enable the log of `torque`(http://yarp.it/git-master/classyarp_1_1dev_1_1ITorqueControl.html).     |
 | `logIMotorEncoders`     | bool     | -     | false     | No     | Enable the log of `motor_encoders`, `motor_velocity` and `motor_acceleration` (http://yarp.it/git-master/classyarp_1_1dev_1_1IMotorEncoders.html).     |
 | `logIControlMode`     | bool     | -     | false     | No     | Enable the log of `control_mode` (http://yarp.it/git-master/classyarp_1_1dev_1_1IControlMode.html.     |
-| `logIInteractionlMode`     | bool     | -     | false     | No     | Enable the log of `interaction_modes` (http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html.     |
+| `logIInteractionMode`     | bool     | -     | false     | No     | Enable the log of `interaction_modes` (http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html.     |
 | `logIPidControl`     | bool     | -     | false     | No     | Enable the log of `position_error`, `position_reference`, `torque_error`, `torque_reference`(http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html).|
 | `logIAmplifierControl`     | bool     | -     | false     | No     | Enable the log of `pwm` and `current` (http://yarp.it/git-master/classyarp_1_1dev_1_1IAmplifierControl.html).     |
 | `logAllQuantities`     | bool     | -     | false     | No     | Enable the log all quantities described above. |

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -104,9 +104,14 @@ bool TelemetryDeviceDumper::loadSettingsFromConfig(yarp::os::Searchable& config)
         settings.logIMotorEncoders = prop.find(logIMotorEncodersOptionName.c_str()).asBool();
     }
 
-    std::string logIControlInteractionModeOptionName = "logIControlInteractionMode";
-    if (prop.check(logIControlInteractionModeOptionName.c_str())) {
-        settings.logIControlInteractionMode = prop.find(logIControlInteractionModeOptionName.c_str()).asBool();
+    std::string logIControlModeOptionName = "logIControlMode";
+    if (prop.check(logIControlModeOptionName.c_str())) {
+        settings.logIControlMode = prop.find(logIControlModeOptionName.c_str()).asBool();
+    }
+
+    std::string logIInteractionModeOptionName = "logIInteractionMode";
+    if (prop.check(logIInteractionModeOptionName.c_str())) {
+        settings.logIInteractionMode = prop.find(logIInteractionModeOptionName.c_str()).asBool();
     }
 
     std::string logIPidControlOptionName = "logIPidControl";
@@ -266,8 +271,10 @@ bool TelemetryDeviceDumper::openRemapperControlBoard(os::Searchable& config)
     if (settings.logAllQuantities || settings.logIAmplifierControl) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.amp);
     }
-    if (settings.logAllQuantities || settings.logIControlInteractionMode) {
+    if (settings.logAllQuantities || settings.logIControlMode) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.cmod);
+    }
+    if (settings.logAllQuantities || settings.logIInteractionMode) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.imod);
     }
     if (settings.logAllQuantities || settings.logITorqueControl) {
@@ -370,9 +377,11 @@ bool TelemetryDeviceDumper::configBufferManager(yarp::os::Searchable& conf) {
         ok = ok && bufferManager.addChannel({ "motor_velocity", {motorVel.size(), 1} });
         ok = ok && bufferManager.addChannel({ "motor_accelerarion", {motorAcc.size(), 1} });
     }
-    // TODO check if it better convert int -> double
-    if (ok && (settings.logIControlInteractionMode || settings.logAllQuantities)) {
+    
+    if (ok && (settings.logIControlMode || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "control_mode", {controlModes.size(), 1} });
+    }
+    if (ok && (settings.logIInteractionMode || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "interaction_mode", {interactionModes.size(), 1} });
     }
 
@@ -596,7 +605,7 @@ void TelemetryDeviceDumper::readSensors()
     }
 
     // Read modes
-    if (settings.logIControlInteractionMode || settings.logAllQuantities) {
+    if (settings.logIControlMode || settings.logAllQuantities) {
         for (int i = 0; i < interactionModes.size(); i++)
         {
             int tmp;
@@ -612,7 +621,9 @@ void TelemetryDeviceDumper::readSensors()
         {
             bufferManager.push_back(controlModes, "control_modes");
         }
+    }
 
+    if (settings.logIInteractionMode || settings.logAllQuantities) {
         for (int i = 0; i < interactionModes.size(); i++)
         {
             yarp::dev::InteractionModeEnum tmp;

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -375,7 +375,7 @@ bool TelemetryDeviceDumper::configBufferManager(yarp::os::Searchable& conf) {
     if (ok && (settings.logIMotorEncoders || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "motor_encoder", {motorEnc.size(), 1} });
         ok = ok && bufferManager.addChannel({ "motor_velocity", {motorVel.size(), 1} });
-        ok = ok && bufferManager.addChannel({ "motor_accelerarion", {motorAcc.size(), 1} });
+        ok = ok && bufferManager.addChannel({ "motor_acceleration", {motorAcc.size(), 1} });
     }
     
     if (ok && (settings.logIControlMode || settings.logAllQuantities)) {
@@ -490,7 +490,7 @@ void TelemetryDeviceDumper::readSensors()
         }
         else
         {
-            bufferManager.push_back(jointPosErr, "potition_error");
+            bufferManager.push_back(jointPosErr, "position_error");
         }
 
         ok = remappedControlBoardInterfaces.pid->getPidReferences(VOCAB_PIDTYPE_POSITION, jointPosRef.data());
@@ -501,7 +501,7 @@ void TelemetryDeviceDumper::readSensors()
         }
         else
         {
-            bufferManager.push_back(jointPosRef, "potition_reference");
+            bufferManager.push_back(jointPosRef, "position_reference");
         }
 
 
@@ -619,7 +619,7 @@ void TelemetryDeviceDumper::readSensors()
         }
         else
         {
-            bufferManager.push_back(controlModes, "control_modes");
+            bufferManager.push_back(controlModes, "control_mode");
         }
     }
 

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -74,13 +74,13 @@ bool TelemetryDeviceDumper::loadSettingsFromConfig(yarp::os::Searchable& config)
 
     std::string useJointVelocityOptionName = "logJointVelocity";
     if (prop.check(useJointVelocityOptionName.c_str())) {
-        yWarning() << "telemetryDeviceDumper: logJointVelocity is deprecated, use logEncoderQuantities instead.";
+        yWarning() << "telemetryDeviceDumper: logJointVelocity is deprecated, use logIEncoders instead.";
         settings.logJointVelocity = prop.find(useJointVelocityOptionName.c_str()).asBool();
     }
 
     std::string useJointAccelerationOptionName = "logJointAcceleration";
     if (prop.check(useJointAccelerationOptionName.c_str())) {
-        yWarning() << "telemetryDeviceDumper: logJointAcceleration is deprecated, use logEncoderQuantities instead.";
+        yWarning() << "telemetryDeviceDumper: logJointAcceleration is deprecated, use logIEncoders instead.";
         settings.logJointAcceleration = prop.find(useJointAccelerationOptionName.c_str()).asBool();
     }
 
@@ -89,34 +89,34 @@ bool TelemetryDeviceDumper::loadSettingsFromConfig(yarp::os::Searchable& config)
         settings.logAllQuantities = prop.find(logAllQuantitiesOptionName.c_str()).asBool();
     }
 
-    std::string logEncoderQuantitiesOptionName = "logEncoderQuantities";
-    if (prop.check(logEncoderQuantitiesOptionName.c_str())) {
-        settings.logEncoderQuantities = prop.find(logEncoderQuantitiesOptionName.c_str()).asBool();
+    std::string logIEncodersOptionName = "logIEncoders";
+    if (prop.check(logIEncodersOptionName.c_str())) {
+        settings.logIEncoders = prop.find(logIEncodersOptionName.c_str()).asBool();
     }
 
-    std::string logTorqueQuantitiesOptionName = "logTorqueQuantities";
-    if (prop.check(logTorqueQuantitiesOptionName.c_str())) {
-        settings.logTorqueQuantities = prop.find(logTorqueQuantitiesOptionName.c_str()).asBool();
+    std::string logITorqueControlOptionName = "logITorqueControl";
+    if (prop.check(logITorqueControlOptionName.c_str())) {
+        settings.logITorqueControl = prop.find(logITorqueControlOptionName.c_str()).asBool();
     }
 
-    std::string logMotorQuantitiesOptionName = "logMotorQuantities";
-    if (prop.check(logMotorQuantitiesOptionName.c_str())) {
-        settings.logMotorQuantities = prop.find(logMotorQuantitiesOptionName.c_str()).asBool();
+    std::string logIMotorEncodersOptionName = "logIMotorEncoders";
+    if (prop.check(logIMotorEncodersOptionName.c_str())) {
+        settings.logIMotorEncoders = prop.find(logIMotorEncodersOptionName.c_str()).asBool();
     }
 
-    std::string logModesQuantitiesOptionName = "logModesQuantities";
-    if (prop.check(logModesQuantitiesOptionName.c_str())) {
-        settings.logModesQuantities = prop.find(logModesQuantitiesOptionName.c_str()).asBool();
+    std::string logIControlInteractionModeOptionName = "logIControlInteractionMode";
+    if (prop.check(logIControlInteractionModeOptionName.c_str())) {
+        settings.logIControlInteractionMode = prop.find(logIControlInteractionModeOptionName.c_str()).asBool();
     }
 
-    std::string logPIDQuantitiesOptionName = "logPIDQuantities";
-    if (prop.check(logPIDQuantitiesOptionName.c_str())) {
-        settings.logPIDQuantities = prop.find(logPIDQuantitiesOptionName.c_str()).asBool();
+    std::string logIPidControlOptionName = "logIPidControl";
+    if (prop.check(logIPidControlOptionName.c_str())) {
+        settings.logIPidControl = prop.find(logIPidControlOptionName.c_str()).asBool();
     }
 
-    std::string logAmplifierQuantitiesOptionName = "logAmplifierQuantities";
-    if (prop.check(logAmplifierQuantitiesOptionName.c_str())) {
-        settings.logAmplifierQuantities = prop.find(logAmplifierQuantitiesOptionName.c_str()).asBool();
+    std::string logIAmplifierControlOptionName = "logIAmplifierControl";
+    if (prop.check(logIAmplifierControlOptionName.c_str())) {
+        settings.logIAmplifierControl = prop.find(logIAmplifierControlOptionName.c_str()).asBool();
     }
 
     std::string useRadians = "useRadians";
@@ -253,24 +253,24 @@ bool TelemetryDeviceDumper::openRemapperControlBoard(os::Searchable& config)
     // View relevant interfaces for the remappedControlBoard
     ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.multwrap);
     // TODO: check if it has to be enabled by options
-    if (settings.logAllQuantities || settings.logEncoderQuantities
+    if (settings.logAllQuantities || settings.logIEncoders
         || settings.logJointVelocity || settings.logJointAcceleration ) { // deprecated since v0.1.0
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.encs);
     }
-    if (settings.logAllQuantities || settings.logMotorQuantities) {
+    if (settings.logAllQuantities || settings.logIMotorEncoders) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.imotenc);
     }
-    if (settings.logAllQuantities || settings.logPIDQuantities) {
+    if (settings.logAllQuantities || settings.logIPidControl) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.pid);
     }
-    if (settings.logAllQuantities || settings.logAmplifierQuantities) {
+    if (settings.logAllQuantities || settings.logIAmplifierControl) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.amp);
     }
-    if (settings.logAllQuantities || settings.logModesQuantities) {
+    if (settings.logAllQuantities || settings.logIControlInteractionMode) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.cmod);
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.imod);
     }
-    if (settings.logAllQuantities || settings.logTorqueQuantities) {
+    if (settings.logAllQuantities || settings.logITorqueControl) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.itrq);
     }
     if (!ok)
@@ -339,39 +339,39 @@ void TelemetryDeviceDumper::resizeBuffers(int size) {
 bool TelemetryDeviceDumper::configBufferManager(yarp::os::Searchable& conf) {
     bool ok{ true };
 
-    if (ok && (settings.logEncoderQuantities || settings.logAllQuantities)) {
+    if (ok && (settings.logIEncoders || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "encoders", {jointPos.size(), 1} });
     }
     
-    if (ok && (settings.logJointVelocity || settings.logEncoderQuantities || settings.logAllQuantities)) {
+    if (ok && (settings.logJointVelocity || settings.logIEncoders || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "velocity", {jointVel.size(), 1} });
     }
 
-    if (ok && (settings.logJointAcceleration || settings.logEncoderQuantities || settings.logAllQuantities)) {
+    if (ok && (settings.logJointAcceleration || settings.logIEncoders || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "acceleration", {jointAcc.size(), 1} });
     }
 
     // TODO check if it is more convenient having more BM
-    if (ok && (settings.logPIDQuantities || settings.logAllQuantities)) {
+    if (ok && (settings.logIPidControl || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "position_error", {jointPosErr.size(), 1} });
         ok = ok && bufferManager.addChannel({ "position_reference", {jointPosRef.size(), 1} });
         ok = ok && bufferManager.addChannel({ "torque_error", {jointTrqErr.size(), 1} });
         ok = ok && bufferManager.addChannel({ "torque_reference", {jointTrqRef.size(), 1} });
     }
-    if (ok && (settings.logAmplifierQuantities || settings.logAllQuantities)) {
+    if (ok && (settings.logIAmplifierControl || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "pwm", {jointPWM.size(), 1} });
         ok = ok && bufferManager.addChannel({ "current", {jointCurr.size(), 1} });
     }
-    if (ok && (settings.logTorqueQuantities || settings.logAllQuantities)) {
+    if (ok && (settings.logITorqueControl || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "torque", {jointTrq.size(), 1} });
     }
-    if (ok && (settings.logMotorQuantities || settings.logAllQuantities)) {
+    if (ok && (settings.logIMotorEncoders || settings.logAllQuantities)) {
         ok = ok && bufferManager.addChannel({ "motor_encoder", {motorEnc.size(), 1} });
         ok = ok && bufferManager.addChannel({ "motor_velocity", {motorVel.size(), 1} });
         ok = ok && bufferManager.addChannel({ "motor_accelerarion", {motorAcc.size(), 1} });
     }
     // TODO check if it better convert int -> double
-    if (ok && (settings.logModesQuantities || settings.logAllQuantities)) {
+    if (ok && (settings.logIControlInteractionMode || settings.logAllQuantities)) {
         ok = ok && bufferManager_modes.addChannel({ "control_mode", {controlModes.size(), 1} });
         ok = ok && bufferManager_modes.addChannel({ "interaction_mode", {interactionModes.size(), 1} });
     }
@@ -428,7 +428,7 @@ void TelemetryDeviceDumper::readSensors()
 {
     bool ok;
     // Read encoders
-    if (settings.logEncoderQuantities || settings.logAllQuantities) {
+    if (settings.logIEncoders || settings.logAllQuantities) {
         sensorsReadCorrectly = remappedControlBoardInterfaces.encs->getEncoders(jointPos.data());
         if (!sensorsReadCorrectly)
         {
@@ -442,7 +442,7 @@ void TelemetryDeviceDumper::readSensors()
 
     // At the moment we are assuming that all joints are revolute
 
-    if (settings.logJointVelocity || settings.logEncoderQuantities || settings.logAllQuantities)
+    if (settings.logJointVelocity || settings.logIEncoders || settings.logAllQuantities)
     {
         ok = remappedControlBoardInterfaces.encs->getEncoderSpeeds(jointVel.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
@@ -457,7 +457,7 @@ void TelemetryDeviceDumper::readSensors()
 
     }
 
-    if (settings.logJointAcceleration || settings.logEncoderQuantities || settings.logAllQuantities)
+    if (settings.logJointAcceleration || settings.logIEncoders || settings.logAllQuantities)
     {
         ok = remappedControlBoardInterfaces.encs->getEncoderAccelerations(jointAcc.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
@@ -474,7 +474,7 @@ void TelemetryDeviceDumper::readSensors()
     }
     
     // Read PID
-    if (settings.logPIDQuantities || settings.logAllQuantities) {
+    if (settings.logIPidControl || settings.logAllQuantities) {
         ok = remappedControlBoardInterfaces.pid->getPidErrors(VOCAB_PIDTYPE_POSITION, jointPosErr.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
         if (!ok)
@@ -521,7 +521,7 @@ void TelemetryDeviceDumper::readSensors()
         }
     }
     // Read amplifier
-    if (settings.logAmplifierQuantities || settings.logAllQuantities) {
+    if (settings.logIAmplifierControl || settings.logAllQuantities) {
         for (int j = 0; j < jointPWM.size(); j++)
         {
             ok &= remappedControlBoardInterfaces.amp->getPWM(j, &jointPWM[j]);
@@ -548,7 +548,7 @@ void TelemetryDeviceDumper::readSensors()
         }
     }
     // Read torque
-    if (settings.logTorqueQuantities || settings.logAllQuantities) {
+    if (settings.logITorqueControl || settings.logAllQuantities) {
         ok = remappedControlBoardInterfaces.itrq->getTorques(jointTrq.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
         if (!ok)
@@ -562,7 +562,7 @@ void TelemetryDeviceDumper::readSensors()
     }
 
     // Read motor
-    if (settings.logMotorQuantities || settings.logAllQuantities) {
+    if (settings.logIMotorEncoders || settings.logAllQuantities) {
         ok = remappedControlBoardInterfaces.imotenc->getMotorEncoders(motorEnc.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
         if (!ok)
@@ -598,7 +598,7 @@ void TelemetryDeviceDumper::readSensors()
     }
 
     // Read modes
-    if (settings.logModesQuantities || settings.logAllQuantities) {
+    if (settings.logIControlInteractionMode || settings.logAllQuantities) {
         ok = remappedControlBoardInterfaces.cmod->getControlModes(controlModes.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
         if (!ok)

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -13,6 +13,13 @@
 #include <yarp/dev/IWrapper.h>
 #include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/dev/IEncoders.h>
+#include <yarp/dev/IMotorEncoders.h>
+#include <yarp/dev/IPidControl.h>
+#include <yarp/dev/IAmplifierControl.h>
+#include <yarp/dev/IControlMode.h>
+#include <yarp/dev/IInteractionMode.h>
+#include <yarp/dev/IMotor.h>
+#include <yarp/dev/ITorqueControl.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/PeriodicThread.h>
@@ -80,17 +87,28 @@ private:
     yarp::dev::PolyDriver remappedControlBoard;
     struct
     {
-        yarp::dev::IEncoders* encs;
-        yarp::dev::IMultipleWrapper* multwrap;
+        yarp::dev::IEncoders* encs{nullptr};
+        yarp::dev::IMotorEncoders* imotenc{ nullptr };
+        yarp::dev::IPidControl* pid{ nullptr };
+        yarp::dev::IAmplifierControl* amp{nullptr};
+        yarp::dev::IControlMode* cmod{ nullptr };
+        yarp::dev::IInteractionMode* imod{ nullptr };
+        yarp::dev::IMotor* imot{ nullptr };
+        yarp::dev::ITorqueControl* itrq{ nullptr };
+        yarp::dev::IMultipleWrapper* multwrap{ nullptr };
     } remappedControlBoardInterfaces;
 
     std::mutex deviceMutex;
     std::atomic<bool> correctlyConfigured{ false }, sensorsReadCorrectly{false};
-    std::vector<double> jointPos, jointVel, jointAcc;
+    std::vector<double> jointPos, jointVel, jointAcc, jointPosErr, jointPosRef,
+                        jointTrqErr, jointTrqRef, jointPWM, jointCurr, jointTrq,
+                        motorEnc, motorVel, motorAcc;
+    std::vector<int> controlModes, interactionModes;
     std::vector<std::string> jointNames;
     TelemetryDeviceDumperSettings settings;
     yarp::telemetry::experimental::BufferConfig m_bufferConfig;
     yarp::telemetry::experimental::BufferManager<double> bufferManager;
+    yarp::telemetry::experimental::BufferManager<int> bufferManager_modes;
 
 
 };

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -36,8 +36,19 @@ namespace yarp::telemetry::experimental {
 
 
 struct TelemetryDeviceDumperSettings {
+    
+    YARP_DEPRECATED_MSG("logJointVelocity is deprecated, use logEncoderQuantities instead.")
     bool logJointVelocity{ false };
+    YARP_DEPRECATED_MSG("logJointAcceleration is deprecated, use logEncoderQuantities instead.")
     bool logJointAcceleration{ false };
+
+    bool logAllQuantities{ false };
+    bool logEncoderQuantities{ true };
+    bool logTorqueQuantities{ false };
+    bool logMotorQuantities{ false };
+    bool logModesQuantities{ false };
+    bool logPIDQuantities{ false };
+    bool logAmplifierQuantities{ false };
     bool useRadians{ false };
     bool saveBufferManagerConfiguration{ false };
 };
@@ -46,7 +57,6 @@ struct TelemetryDeviceDumperSettings {
  *
  */
 class TelemetryDeviceDumper : public yarp::dev::DeviceDriver,
-                              //public yarp::dev::IWrapper,
                               public yarp::dev::IMultipleWrapper,
                               public yarp::os::PeriodicThread
 {
@@ -68,11 +78,6 @@ public:
 
     bool        detachAll() override;
 
-    // IWrapper interface
-    //bool        attach(yarp::dev::PolyDriver* poly) override;
-
-    //bool        detach() override;
-
     void run() override;
 
 private:
@@ -93,7 +98,6 @@ private:
         yarp::dev::IAmplifierControl* amp{nullptr};
         yarp::dev::IControlMode* cmod{ nullptr };
         yarp::dev::IInteractionMode* imod{ nullptr };
-        yarp::dev::IMotor* imot{ nullptr };
         yarp::dev::ITorqueControl* itrq{ nullptr };
         yarp::dev::IMultipleWrapper* multwrap{ nullptr };
     } remappedControlBoardInterfaces;

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -106,13 +106,11 @@ private:
     std::atomic<bool> correctlyConfigured{ false }, sensorsReadCorrectly{false};
     std::vector<double> jointPos, jointVel, jointAcc, jointPosErr, jointPosRef,
                         jointTrqErr, jointTrqRef, jointPWM, jointCurr, jointTrq,
-                        motorEnc, motorVel, motorAcc;
-    std::vector<int> controlModes, interactionModes;
+                        motorEnc, motorVel, motorAcc, controlModes, interactionModes;
     std::vector<std::string> jointNames;
     TelemetryDeviceDumperSettings settings;
     yarp::telemetry::experimental::BufferConfig m_bufferConfig;
     yarp::telemetry::experimental::BufferManager<double> bufferManager;
-    yarp::telemetry::experimental::BufferManager<int> bufferManager_modes;
 
 
 };

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -46,7 +46,8 @@ struct TelemetryDeviceDumperSettings {
     bool logIEncoders{ true };
     bool logITorqueControl{ false };
     bool logIMotorEncoders{ false };
-    bool logIControlInteractionMode{ false };
+    bool logIControlMode{ false };
+    bool logIInteractionMode{ false };
     bool logIPidControl{ false };
     bool logIAmplifierControl{ false };
     bool useRadians{ false };

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -43,12 +43,12 @@ struct TelemetryDeviceDumperSettings {
     bool logJointAcceleration{ false };
 
     bool logAllQuantities{ false };
-    bool logEncoderQuantities{ true };
-    bool logTorqueQuantities{ false };
-    bool logMotorQuantities{ false };
-    bool logModesQuantities{ false };
-    bool logPIDQuantities{ false };
-    bool logAmplifierQuantities{ false };
+    bool logIEncoders{ true };
+    bool logITorqueControl{ false };
+    bool logIMotorEncoders{ false };
+    bool logIControlInteractionMode{ false };
+    bool logIPidControl{ false };
+    bool logIAmplifierControl{ false };
     bool useRadians{ false };
     bool saveBufferManagerConfiguration{ false };
 };


### PR DESCRIPTION
It fixes #113
There are still open points, for now it simply dump everythin, we should define how to
group these quantities under options.

TODO

- [x] Define proper options
- [x] Think about the possibility of using more than one BufferManager
- [x] Think if it is better to just convert CM and IM to doubles
- [x] Write documentation
- [x] Test
- [ ] BONUS: get rid of copy-paste code