### PR TITLE
Added possibility to explicitly set the timestamp of a Record with push_back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the possibility to specify the time of a ``Record`` with ``push_back``.
+
 ## [0.1.0] - 2021-04-02
 
 First release of `yarp-telemetry`, compatible with YARP 3.4.

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
@@ -259,6 +259,21 @@ public:
      * @brief Push a new element in the var_name channel.
      * The var_name channels must exist, otherwise an exception is thrown.
      *
+     * @param[in] elem The element to be pushed(via copy) in the channel.
+     * @param[in] ts The timestamp of the element to be pushed.
+     * @param[in] var_name The name of the channel.
+     */
+    inline void push_back(const std::vector<T>& elem, double ts, const std::string& var_name)
+    {
+        assert(elem.size() == m_buffer_map.at(var_name).m_dimensions[0] * m_buffer_map.at(var_name).m_dimensions[1]);
+        std::scoped_lock<std::mutex> lock{ m_buffer_map.at(var_name).m_buff_mutex };
+        m_buffer_map.at(var_name).m_buffer.push_back(Record<T>(ts, elem));
+    }
+
+    /**
+     * @brief Push a new element in the var_name channel.
+     * The var_name channels must exist, otherwise an exception is thrown.
+     *
      * @param[in] elem The element to be pushed(via move) in the channel.
      * @param[in] var_name The name of the channel.
      */


### PR DESCRIPTION
After a discussion with @prashanthr05, we realized that sometimes it is important to store data in different channels but with the same timestamp. 

In principle, this would be possible by storing structs of data for example, but this is not currently supported. An easy workaround is to store all the data in separated vectors. On the other hand, to make sure that all the data is saved in a synchronized way, it is necessary to specify also the timestamp.

This may also be helpful when storing the data read from the yarp interfaces, saving the timestamp retrieved by the ``yarp`` interface, rather than the one obtained by the application.