### PR TITLE
Remove YARP_telemetry_DEPRECATED_API definition

### DIFF
--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/api.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/api.h
@@ -19,8 +19,6 @@
 #    define YARP_telemetry_API YARP_IMPORT
 #    define YARP_telemetry_EXTERN YARP_IMPORT_EXTERN
 #  endif
-#  define YARP_telemetry_DEPRECATED_API YARP_DEPRECATED_API
-#  define YARP_telemetry_DEPRECATED_API_MSG(X) YARP_DEPRECATED_API_MSG(X)
 #endif
 
 #endif // YARP_TELEMETRY_API_H


### PR DESCRIPTION
I realized that the `YARP_DEPRECATED_API` definition is broken, and won't work anyway outside `YARP_os`
AFAIK, this is the only place outside YARP where this definition is used, therefore I'm planning to change this to a proper `EXPORT`/`IMPORT` definition in YARP master, and I'm not sure if it is possible to do this ensuring the compatibility, without breaking the API.

This means that current definition will work with YARP 3.4 only, and the new definition will require YARP master which is unreleased yet.
Therefore I suggest to remove these 2 lines (I don't think there is any deprecated API in yarp_telemetry yet), and to wait until YARP 3.5 is released to depend on YARP 3.5 and fix the definition.

