### PR TITLE
Fix compilation when using Ubuntu 18.04 

### DIFF
--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -55,6 +55,11 @@ target_link_libraries(YARP_telemetry PUBLIC  Boost::boost
                                              Threads::Threads
                                              YARP::YARP_conf
                                      PRIVATE nlohmann_json::nlohmann_json)
+# Support using filesystem on GCC < 9.1,
+# see https://en.cppreference.com/w/cpp/filesystem#Notes
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1))
+  target_link_libraries(YARP_telemetry PUBLIC stdc++fs)
+endif()
 list(APPEND YARP_telemetry_PUBLIC_DEPS Boost
                                        matioCpp
                                        Threads)

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
@@ -26,7 +26,18 @@
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
-#include <filesystem>
+
+#ifndef __has_include
+  static_assert(false, "__has_include not supported");
+#else
+#  if __has_include(<filesystem>)
+#    include <filesystem>
+     namespace yarp_telemetry_fs = std::filesystem;
+#  elif __has_include(<experimental/filesystem>)
+#    include <experimental/filesystem>
+     namespace yarp_telemetry_fs = std::experimental::filesystem;
+#  endif
+#endif
 
 
 namespace yarp::telemetry::experimental {
@@ -136,7 +147,7 @@ public:
             ok = ok && enablePeriodicSave(_bufferConfig.save_period);
         }
         populateDescriptionCellArray();
-        if (!m_bufferConfig.path.empty() && !std::filesystem::exists(m_bufferConfig.path)) {
+        if (!m_bufferConfig.path.empty() && !yarp_telemetry_fs::exists(m_bufferConfig.path)) {
             std::cout << m_bufferConfig.path << " does not exists." << std::endl;
             return false;
         }

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
@@ -36,6 +36,8 @@
 #  elif __has_include(<experimental/filesystem>)
 #    include <experimental/filesystem>
      namespace yarp_telemetry_fs = std::experimental::filesystem;
+#  else
+     static_assert(false, "Neither <filesystem> nor <experimental/filesystem> headers are present in the system, but they are required"); 
 #  endif
 #endif
 


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/731 . 

As discussed in https://github.com/robotology/robotology-superbuild/issues/481, we plan to support the compilation of this library on Ubuntu 18.04 at least in the next future. For this reason, this PR fixes the library to compile correctly when on Ubuntu 18.04, that was broken after https://github.com/robotology/yarp-telemetry/pull/132 .

Please squash when merging the PR, thanks! 