### PR TITLE
Fix close method of DeviceDumper

### DIFF
--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -419,10 +419,7 @@ bool TelemetryDeviceDumper::close()
 {
     correctlyConfigured = false;
     remappedControlBoard.close();
-    // Flush all the remaining data.
-    if (!m_bufferConfig.auto_save) {
-        bufferManager.saveToFile();
-    }
+
     bool ok = true;
     if (settings.saveBufferManagerConfiguration) {
         auto buffConfToSave = bufferManager.getBufferConfig();

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -420,7 +420,9 @@ bool TelemetryDeviceDumper::close()
     correctlyConfigured = false;
     remappedControlBoard.close();
     // Flush all the remaining data.
-    bufferManager.saveToFile();
+    if (!m_bufferConfig.auto_save) {
+        bufferManager.saveToFile();
+    }
     bool ok = true;
     if (settings.saveBufferManagerConfiguration) {
         auto buffConfToSave = bufferManager.getBufferConfig();


### PR DESCRIPTION
I noticed this log message when using the dumper with the option autosave:
```
acceleration does not contain data, skipping
velocity does not contain data, skipping
encoders does not contain data, skipping
```

By checking the code I noticed that when the `close()` is called, it tries to save data to a file. But in case the option autosave is `true`, data have already been written. I added a statement to check whether the option is true. If yes, the saving is not called.

cc @prashanthr05