### PR TITLE
telemetryDeviceDumper: add log of Odometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the log of the estimated odometry from `yarp::dev::Nav2D::ILocalization2D`.
+- Deprecated the `logAllQuantities` option in favour of `logControlBoardQuantities`.
+
 ## [0.2.0] - 2021-05-19
 
 - Added the possibility to specify the time of a ``Record`` with ``push_back``.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_de
 | `logIInteractionMode`     | bool     | -     | false     | No     | Enable the log of `interaction_modes` (http://yarp.it/git-master/classyarp_1_1dev_1_1IInteractionMode.html.     |
 | `logIPidControl`     | bool     | -     | false     | No     | Enable the log of `position_error`, `position_reference`, `torque_error`, `torque_reference`(http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html).|
 | `logIAmplifierControl`     | bool     | -     | false     | No     | Enable the log of `pwm` and `current` (http://yarp.it/git-master/classyarp_1_1dev_1_1IAmplifierControl.html).     |
-| `logAllQuantities`     | bool     | -     | false     | No     | Enable the log all quantities described above. |
+| `logAllQuantities` (DEPRECATED)    | bool     | -     | false     | No     | Enable the log all quantities described above. |
+| `logControlBoardQuantities` | bool     | -     | false     | No     | Enable the log of all the quantities that requires the attach to a control board (`logIEncoders`, `logITorqueControl`, `logIMotorEncoders`, `logIControlMode`, `logIInteractionMode`, `logIPidControl`, `logIAmplifierControl`). |
+| `logILocalization2D` | bool     | -     | false     | No     | Enable the log of `odometry_data` (http://yarp.it/git-master/classyarp_1_1dev_1_1Nav2D_1_1ILocalization2D.html). For properly logging the odometry data [this patch](https://github.com/robotology/yarp/pull/2602) is needed on YARP side |
 | `saveBufferManagerConfiguration`     | bool     | -    | false     | No     | Enable the save of the configuration of the BufferManager into `path`+ `"bufferConfig"` + `experimentName` + `".json"`     |
 | `json_file`     | string     | -     | -     | No     | Configure the `yarp::telemetry::experimental::BufferManager`s reading from a json file like [in Example configuration file](#example-configuration-file). Note that this configuration will overwrite the parameter-by-parameter configuration   |
 | `experimentName`     | string     | -     | -     | Yes     | Prefix of the files that will be saved. The files will be named: `experimentName`+`timestamp`+ `".mat"`.     |
@@ -321,6 +323,7 @@ The `telemetryDeviceDumper` is a [yarp device](http://yarp.it/git-master/note_de
 | `position_reference` | [`yarp::dev::IPidControl::getPidReferences`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da) |
 | `torque_error`       | [`yarp::dev::IPidControl::getPidErrors`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#aea29e0fdf34f819ac69a3b940556ba28) |
 | `torque_reference`   | [`yarp::dev::IPidControl::getPidReferences`](http://yarp.it/git-master/classyarp_1_1dev_1_1IPidControl.html#a29e8f684a15d859229a9ae2902f886da) |
+| `odometry_data   `   | [`yarp::dev::Nav2D::ILocalization2D::getEstimatedOdometry`](http://yarp.it/git-master/classyarp_1_1dev_1_1Nav2D_1_1ILocalization2D.html#a02bff57282777ce7511b671abd4c95f0) |
 
 ### Example of xml
 

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.cpp
@@ -84,9 +84,15 @@ bool TelemetryDeviceDumper::loadSettingsFromConfig(yarp::os::Searchable& config)
         settings.logJointAcceleration = prop.find(useJointAccelerationOptionName.c_str()).asBool();
     }
 
+    std::string logControlBoardQuantitiesOptionName = "logControlBoardQuantities";
+    if (prop.check(logControlBoardQuantitiesOptionName.c_str())) {
+        settings.logControlBoardQuantities = prop.find(logControlBoardQuantitiesOptionName.c_str()).asBool();
+    }
+
     std::string logAllQuantitiesOptionName = "logAllQuantities";
     if (prop.check(logAllQuantitiesOptionName.c_str())) {
-        settings.logAllQuantities = prop.find(logAllQuantitiesOptionName.c_str()).asBool();
+        yWarning() << "telemetryDeviceDumper: logAllQuantities is deprecated, use logControlBoardQuantities instead";
+        settings.logControlBoardQuantities = prop.find(logAllQuantitiesOptionName.c_str()).asBool();
     }
 
     std::string logIEncodersOptionName = "logIEncoders";
@@ -281,26 +287,26 @@ bool TelemetryDeviceDumper::openRemapperControlBoard(os::Searchable& config)
     // View relevant interfaces for the remappedControlBoard
     ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.multwrap);
     // TODO: check if it has to be enabled by options
-    if (settings.logAllQuantities || settings.logIEncoders
+    if (settings.logControlBoardQuantities || settings.logIEncoders
         || settings.logJointVelocity || settings.logJointAcceleration ) { // deprecated since v0.1.0
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.encs);
     }
-    if (settings.logAllQuantities || settings.logIMotorEncoders) {
+    if (settings.logControlBoardQuantities || settings.logIMotorEncoders) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.imotenc);
     }
-    if (settings.logAllQuantities || settings.logIPidControl) {
+    if (settings.logControlBoardQuantities || settings.logIPidControl) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.pid);
     }
-    if (settings.logAllQuantities || settings.logIAmplifierControl) {
+    if (settings.logControlBoardQuantities || settings.logIAmplifierControl) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.amp);
     }
-    if (settings.logAllQuantities || settings.logIControlMode) {
+    if (settings.logControlBoardQuantities || settings.logIControlMode) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.cmod);
     }
-    if (settings.logAllQuantities || settings.logIInteractionMode) {
+    if (settings.logControlBoardQuantities || settings.logIInteractionMode) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.imod);
     }
-    if (settings.logAllQuantities || settings.logITorqueControl) {
+    if (settings.logControlBoardQuantities || settings.logITorqueControl) {
         ok = ok && remappedControlBoard.view(remappedControlBoardInterfaces.itrq);
     }
     if (!ok)
@@ -371,42 +377,42 @@ void TelemetryDeviceDumper::resizeBuffers(int size) {
 bool TelemetryDeviceDumper::configBufferManager(yarp::os::Searchable& conf) {
     bool ok{ true };
 
-    if (ok && (settings.logIEncoders || settings.logAllQuantities)) {
+    if (ok && (settings.logIEncoders || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "encoders", {jointPos.size(), 1} });
     }
 
-    if (ok && (settings.logJointVelocity || settings.logIEncoders || settings.logAllQuantities)) {
+    if (ok && (settings.logJointVelocity || settings.logIEncoders || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "velocity", {jointVel.size(), 1} });
     }
 
-    if (ok && (settings.logJointAcceleration || settings.logIEncoders || settings.logAllQuantities)) {
+    if (ok && (settings.logJointAcceleration || settings.logIEncoders || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "acceleration", {jointAcc.size(), 1} });
     }
 
     // TODO check if it is more convenient having more BM
-    if (ok && (settings.logIPidControl || settings.logAllQuantities)) {
+    if (ok && (settings.logIPidControl || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "position_error", {jointPosErr.size(), 1} });
         ok = ok && bufferManager.addChannel({ "position_reference", {jointPosRef.size(), 1} });
         ok = ok && bufferManager.addChannel({ "torque_error", {jointTrqErr.size(), 1} });
         ok = ok && bufferManager.addChannel({ "torque_reference", {jointTrqRef.size(), 1} });
     }
-    if (ok && (settings.logIAmplifierControl || settings.logAllQuantities)) {
+    if (ok && (settings.logIAmplifierControl || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "pwm", {jointPWM.size(), 1} });
         ok = ok && bufferManager.addChannel({ "current", {jointCurr.size(), 1} });
     }
-    if (ok && (settings.logITorqueControl || settings.logAllQuantities)) {
+    if (ok && (settings.logITorqueControl || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "torque", {jointTrq.size(), 1} });
     }
-    if (ok && (settings.logIMotorEncoders || settings.logAllQuantities)) {
+    if (ok && (settings.logIMotorEncoders || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "motor_encoder", {motorEnc.size(), 1} });
         ok = ok && bufferManager.addChannel({ "motor_velocity", {motorVel.size(), 1} });
         ok = ok && bufferManager.addChannel({ "motor_acceleration", {motorAcc.size(), 1} });
     }
 
-    if (ok && (settings.logIControlMode || settings.logAllQuantities)) {
+    if (ok && (settings.logIControlMode || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "control_mode", {controlModes.size(), 1} });
     }
-    if (ok && (settings.logIInteractionMode || settings.logAllQuantities)) {
+    if (ok && (settings.logIInteractionMode || settings.logControlBoardQuantities)) {
         ok = ok && bufferManager.addChannel({ "interaction_mode", {interactionModes.size(), 1} });
     }
 
@@ -466,7 +472,7 @@ void TelemetryDeviceDumper::readSensors()
 {
     bool ok;
     // Read encoders
-    if (settings.logIEncoders || settings.logAllQuantities) {
+    if (settings.logIEncoders || settings.logControlBoardQuantities) {
         sensorsReadCorrectly = remappedControlBoardInterfaces.encs->getEncoders(jointPos.data());
         if (!sensorsReadCorrectly)
         {
@@ -480,7 +486,7 @@ void TelemetryDeviceDumper::readSensors()
 
     // At the moment we are assuming that all joints are revolute
 
-    if (settings.logJointVelocity || settings.logIEncoders || settings.logAllQuantities)
+    if (settings.logJointVelocity || settings.logIEncoders || settings.logControlBoardQuantities)
     {
         ok = remappedControlBoardInterfaces.encs->getEncoderSpeeds(jointVel.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
@@ -495,7 +501,7 @@ void TelemetryDeviceDumper::readSensors()
 
     }
 
-    if (settings.logJointAcceleration || settings.logIEncoders || settings.logAllQuantities)
+    if (settings.logJointAcceleration || settings.logIEncoders || settings.logControlBoardQuantities)
     {
         ok = remappedControlBoardInterfaces.encs->getEncoderAccelerations(jointAcc.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
@@ -512,7 +518,7 @@ void TelemetryDeviceDumper::readSensors()
     }
 
     // Read PID
-    if (settings.logIPidControl || settings.logAllQuantities) {
+    if (settings.logIPidControl || settings.logControlBoardQuantities) {
         ok = remappedControlBoardInterfaces.pid->getPidErrors(VOCAB_PIDTYPE_POSITION, jointPosErr.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
         if (!ok)
@@ -559,7 +565,7 @@ void TelemetryDeviceDumper::readSensors()
         }
     }
     // Read amplifier
-    if (settings.logIAmplifierControl || settings.logAllQuantities) {
+    if (settings.logIAmplifierControl || settings.logControlBoardQuantities) {
         for (int j = 0; j < jointPWM.size(); j++)
         {
             ok &= remappedControlBoardInterfaces.amp->getPWM(j, &jointPWM[j]);
@@ -586,7 +592,7 @@ void TelemetryDeviceDumper::readSensors()
         }
     }
     // Read torque
-    if (settings.logITorqueControl || settings.logAllQuantities) {
+    if (settings.logITorqueControl || settings.logControlBoardQuantities) {
         ok = remappedControlBoardInterfaces.itrq->getTorques(jointTrq.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
         if (!ok)
@@ -600,7 +606,7 @@ void TelemetryDeviceDumper::readSensors()
     }
 
     // Read motor
-    if (settings.logIMotorEncoders || settings.logAllQuantities) {
+    if (settings.logIMotorEncoders || settings.logControlBoardQuantities) {
         ok = remappedControlBoardInterfaces.imotenc->getMotorEncoders(motorEnc.data());
         sensorsReadCorrectly = sensorsReadCorrectly && ok;
         if (!ok)
@@ -636,7 +642,7 @@ void TelemetryDeviceDumper::readSensors()
     }
 
     // Read modes
-    if (settings.logIControlMode || settings.logAllQuantities) {
+    if (settings.logIControlMode || settings.logControlBoardQuantities) {
         for (int i = 0; i < interactionModes.size(); i++)
         {
             int tmp;
@@ -654,7 +660,7 @@ void TelemetryDeviceDumper::readSensors()
         }
     }
 
-    if (settings.logIInteractionMode || settings.logAllQuantities) {
+    if (settings.logIInteractionMode || settings.logControlBoardQuantities) {
         for (int i = 0; i < interactionModes.size(); i++)
         {
             yarp::dev::InteractionModeEnum tmp;

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -54,6 +54,7 @@ struct TelemetryDeviceDumperSettings {
     bool logILocalization2D{ false };
     bool useRadians{ false };
     bool saveBufferManagerConfiguration{ false };
+    std::string localizationRemoteName{ "" };
 };
 /**
  * @brief FILL DOCUMENTATION
@@ -93,7 +94,7 @@ private:
     void resizeBuffers(int size);
     bool configBufferManager(yarp::os::Searchable& config);
     /** Remapped controlboard containg the axes for which the joint torques are estimated */
-    yarp::dev::PolyDriver remappedControlBoard;
+    yarp::dev::PolyDriver remappedControlBoard, localization2DClient;
     struct
     {
         yarp::dev::IEncoders* encs{nullptr};

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -18,6 +18,7 @@
 #include <yarp/dev/IAmplifierControl.h>
 #include <yarp/dev/IControlMode.h>
 #include <yarp/dev/IInteractionMode.h>
+#include <yarp/dev/ILocalization2D.h>
 #include <yarp/dev/IMotor.h>
 #include <yarp/dev/ITorqueControl.h>
 #include <yarp/dev/PolyDriver.h>
@@ -50,6 +51,7 @@ struct TelemetryDeviceDumperSettings {
     bool logIInteractionMode{ false };
     bool logIPidControl{ false };
     bool logIAmplifierControl{ false };
+    bool logILocalization2D{ false };
     bool useRadians{ false };
     bool saveBufferManagerConfiguration{ false };
 };
@@ -87,6 +89,7 @@ private:
     bool attachAllControlBoards(const yarp::dev::PolyDriverList& p_list);
     bool openRemapperControlBoard(yarp::os::Searchable& config);
     void readSensors();
+    void readOdometryData();
     void resizeBuffers(int size);
     bool configBufferManager(yarp::os::Searchable& config);
     /** Remapped controlboard containg the axes for which the joint torques are estimated */
@@ -103,11 +106,14 @@ private:
         yarp::dev::IMultipleWrapper* multwrap{ nullptr };
     } remappedControlBoardInterfaces;
 
+    yarp::dev::Nav2D::ILocalization2D* iloc{nullptr};
+
     std::mutex deviceMutex;
     std::atomic<bool> correctlyConfigured{ false }, sensorsReadCorrectly{false};
     std::vector<double> jointPos, jointVel, jointAcc, jointPosErr, jointPosRef,
                         jointTrqErr, jointTrqRef, jointPWM, jointCurr, jointTrq,
-                        motorEnc, motorVel, motorAcc, controlModes, interactionModes;
+                        motorEnc, motorVel, motorAcc, controlModes, interactionModes,
+                        odometryData;
     std::vector<std::string> jointNames;
     TelemetryDeviceDumperSettings settings;
     yarp::telemetry::experimental::BufferConfig m_bufferConfig;

--- a/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
+++ b/src/telemetryDeviceDumper/TelemetryDeviceDumper.h
@@ -43,7 +43,7 @@ struct TelemetryDeviceDumperSettings {
     YARP_DEPRECATED_MSG("logJointAcceleration is deprecated, use logIEncoders instead.")
     bool logJointAcceleration{ false };
 
-    bool logAllQuantities{ false };
+    bool logControlBoardQuantities{ false };
     bool logIEncoders{ true };
     bool logITorqueControl{ false };
     bool logIMotorEncoders{ false };

--- a/src/telemetryDeviceDumper/app/telemetryDeviceDumper_sim.xml
+++ b/src/telemetryDeviceDumper/app/telemetryDeviceDumper_sim.xml
@@ -5,6 +5,8 @@
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="telemetryDeviceDumper" type="telemetryDeviceDumper">
         <param name="axesNames">(torso_pitch,torso_roll,torso_yaw,neck_pitch, neck_roll,neck_yaw,l_shoulder_pitch,l_shoulder_roll,l_shoulder_yaw,l_elbow,l_wrist_prosup,l_wrist_pitch,l_wrist_yaw,r_shoulder_pitch,r_shoulder_roll,r_shoulder_yaw,r_elbow,r_wrist_prosup,r_wrist_pitch,r_wrist_yaw,l_hip_pitch,l_hip_roll,l_hip_yaw,l_knee,l_ankle_pitch,l_ankle_roll,r_hip_pitch,r_hip_roll,r_hip_yaw,r_knee,r_ankle_pitch,r_ankle_roll)</param>
         <param name="logIEncoders">true</param>
+        <param name="logILocalization2D">true</param>
+        <param name="localizationRemoteName">/localizationServer</param>
         <param name="saveBufferManagerConfiguration">true</param>
         <param name="experimentName">test_telemetry</param>
         <param name="path">/home/icub/test_telemetry/</param>


### PR DESCRIPTION
This PR adds the possibility to log the odometry data.
It fixes #126 

There are still some open points:

- Differently from the other data retrieved through the attaching and the control_board_remapper, for the odometry we used the `localization2DClient`, since the localization device can run on different machines from the `r1-base`, and the localization pipeline has never been used with `yarprobotinterface`. We have to discuss the pro and cons of following this approach or the "attach" approach
- Now we added the log odometry to `logAllQuantities` option, but it may break some existing configurations, since on icub the open of the `localization2DClient` will fail. Maybe we should divide in control board quantities from the rest?
- Until now we always assumed that the remapper should be opened, otherwise no data would be logged, but maybe we should allow logging just the odometry(or other future quantities) that does not need the remapper?

We tested with [this self-contained example](https://github.com/robotology/navigation/blob/master/app/robotPathPlannerExamples/scripts/robotPathPlannerExample2.xml), that started correctly

![immagine](https://user-images.githubusercontent.com/19152494/121204740-65d42f00-c877-11eb-887e-64acc16390cf.png)


But we get only:
```
[WARNING] telemetryDeviceDumper warning : odometry_data was not readed correctly
[ERROR] |yarp.device.localization2DClient| getEstimatedOdometry is not yet implemented
[WARNING] telemetryDeviceDumper warning : odometry_data was not readed correctly
[ERROR] |yarp.device.localization2DClient| getEstimatedOdometry is not yet implemented
[WARNING] telemetryDeviceDumper warning : odometry_data was not readed correctly
[ERROR] |yarp.device.localization2DClient| getEstimatedOdometry is not yet implemented
[WARNING] telemetryDeviceDumper warning : odometry_data was not readed correctly
[ERROR] |yarp.device.localization2DClient| getEstimatedOdometry is not yet implemented
``` 


In any case on Friday @AlexAntn should do some tests with r1

TODO: update the documentation