### PR TITLE
Fix Conda CI on Linux avoiding to use the defaults channel

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -24,16 +24,18 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         mamba-version: "*"
-        channels: conda-forge,defaults
+        channels: conda-forge,robotology
         channel-priority: true
 
     - name: Dependencies
       shell: bash -l {0}
       run: |
+        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
+        conda config --remove channels defaults
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology yarp matio-cpp boost-cpp
+        mamba install yarp matio-cpp boost-cpp
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
The CI has been using the defaults channel (even if this was not wanted) for a long time, see https://github.com/conda-incubator/setup-miniconda/issues/186 . However, since yesterday this created a compilation error:
~~~
2021-07-30T02:25:20.1711320Z /usr/share/miniconda/envs/test/x86_64-conda-linux-gnu/include/c++/9.3.0/ctime:80:11: error: '::timespec_get' has not been declared
2021-07-30T02:25:20.1712202Z    80 |   using ::timespec_get;
2021-07-30T02:25:20.1712597Z       |           ^~~~~~~~~~~~
~~~

For this reason, better to cleanup the use of conda channels in the CI, making sure that we don't use `defaults` at all.