### PR TITLE
Set the required version of nlohmann_json to 3.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
 
   FetchContent_Declare(json
     GIT_REPOSITORY https://github.com/nlohmann/json.git
-    GIT_TAG 3.10.0)
+    GIT_TAG v3.10.0)
 
   FetchContent_GetProperties(json)
   if(NOT json_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,13 +73,13 @@ find_package(Threads REQUIRED)
 option(YARP_TELEMETRY_USES_SYSTEM_nlohmann_json OFF)
 # 3.9.2 is unreleased, this option is not working until that version is not released
 if(YARP_TELEMETRY_USES_SYSTEM_nlohmann_json)
-  find_package(nlohmann_json 3.9.2 REQUIRED)
+  find_package(nlohmann_json 3.10.0 REQUIRED)
 else()
   include(FetchContent)
 
   FetchContent_Declare(json
     GIT_REPOSITORY https://github.com/nlohmann/json.git
-    GIT_TAG develop) # awaiting 3.9.2 release for https://github.com/nlohmann/json/issues/2513
+    GIT_TAG 3.10.0)
 
   FetchContent_GetProperties(json)
   if(NOT json_POPULATED)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The depencies are:
 - [Boost](https://www.boost.org/)
 - [YARP](https://www.yarp.it/git-master/install.html) (minimum version 3.4.0)
 - [matio-cpp](https://github.com/dic-iit/matio-cpp#installation) (minimum version 0.1.1)
-- [nlohmann_json](https://github.com/nlohmann/json#integration) (minimum version 3.9.2 - not yet released)
+- [nlohmann_json](https://github.com/nlohmann/json#integration) (minimum version 3.10.0)
 - [Catch2](https://github.com/catchorg/Catch2.git) (v2.13.1, for the unit tests)
 
 ### Linux/macOS


### PR DESCRIPTION
We used to depend to the development branch of `nlohmann_json`, but since a new version has been release (https://github.com/nlohmann/json/releases/tag/v3.10.0) we can use the tag instead.