### PR TITLE
Add the possibility to have multilayer structures in the BufferManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the creation of the dir in the `BufferManager` if the path specified does not exist.
 - Added the `file_indexing` parameter in the `BufferConfig` struct.
 - Add the possibility to specify the saved matfile version in the `BufferManager` class. 
+- Added the possibility to have multilayer structures in the `BufferManager`.
 
 ## [0.3.0] - 2021-10-18
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,58 @@ ans =
     timestamps: [112104.7605783 112104.9608881 112105.1611651]
 
 ```
+### Example nested struct
 
+It is possible to save and dump vectors and matrices into nested `mat` structures. To add an element into the matlab struct the you should use the separator `::`. For instance the to store a vector in `A.B.C.my_vector` you should define the channel name as `A::B::C::my_vector`
+Here is the code snippet for dumping in a `.mat` file 3 samples of the 4x1 vector variables `"one"` and `"two"` into `struct1` and `struct2`.
+
+```c++
+    yarp::telemetry::experimental::BufferConfig bufferConfig;
+    bufferConfig.auto_save = true; // It will save when invoking the destructor
+    bufferConfig.channels = { {"struct1::one",{4,1}}, {"struct1::two",{4,1}}, {"struct2::one",{4,1}} }; // Definition of the elements into substruct
+    bufferConfig.filename = "buffer_manager_test_nested_vector";
+    bufferConfig.n_samples = 3;
+
+    yarp::telemetry::experimental::BufferManager<double> bm_v(bufferConfig);
+    for (int i = 0; i < 10; i++) {
+        bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "struct1::one");
+        yarp::os::Time::delay(0.2);
+        bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "struct1::two");
+        yarp::os::Time::delay(0.2);
+        bm_v.push_back({ (double)i, i/2.0, i/3.0, i/4.0 }, "struct2::one");
+    }
+
+```
+
+```
+buffer_manager_test_nested_vector =
+
+  struct with fields:
+
+    description_list: {[1×0 char]}
+             struct2: [1×1 struct]
+             struct1: [1×1 struct]
+
+>> buffer_manager_test_nested_vector.struct1
+
+ans =
+
+  struct with fields:
+
+    two: [1×1 struct]
+    one: [1×1 struct]
+
+>> buffer_manager_test_nested_vector.struct1.one
+
+ans =
+
+  struct with fields:
+
+          data: [4×1×3 double]
+    dimensions: [4 1 3]
+          name: 'one'
+    timestamps: [1.6415e+09 1.6415e+09 1.6415e+09]
+```
 
 ### Example configuration file
 

--- a/src/examples/telemetry_buffer_manager_example.cpp
+++ b/src/examples/telemetry_buffer_manager_example.cpp
@@ -103,5 +103,24 @@ int main()
         bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "two");
     }
 
+
+    bufferConfig.channels = { {"struct1::one",{4,1}}, {"struct1::two",{4,1}}, {"struct2::one",{4,1}} };
+    bufferConfig.filename = "buffer_manager_test_nested_vector";
+
+    yarp::telemetry::experimental::BufferManager<double> bm_ns(bufferConfig);
+    ok = bm_ns.setNowFunction(now);
+    if (!ok) {
+        std::cout << "Problem setting the clock...."<<std::endl;
+        return 1;
+    }
+
+    for (int i = 0; i < 10; i++) {
+        bm_ns.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "struct1::one");
+        yarp::os::Time::delay(0.2);
+        bm_ns.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "struct1::two");
+        yarp::os::Time::delay(0.2);
+        bm_ns.push_back({ (double)i, i/2.0, i/3.0, i/4.0 }, "struct2::one");
+    }
+
     return 0;
  }

--- a/src/libYARP_telemetry/src/CMakeLists.txt
+++ b/src/libYARP_telemetry/src/CMakeLists.txt
@@ -13,6 +13,7 @@ set(YARP_telemetry_HDRS
   yarp/telemetry/experimental/BufferConfig.h
   yarp/telemetry/experimental/BufferManager.h
   yarp/telemetry/experimental/Record.h
+  yarp/telemetry/experimental/TreeNode.h
 )
 set(YARP_telemetry_SRCS
   yarp/telemetry/experimental/BufferConfig.cpp

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/TreeNode.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/TreeNode.h
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2006-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef YARP_TELEMETRY_TREE_NODE_H
+#define YARP_TELEMETRY_TREE_NODE_H
+
+#include <cstddef>
+#include <unordered_map>
+#include <memory>
+#include <string>
+#include <iostream>
+#include <regex>
+#include <assert.h>
+
+#include <matioCpp/Span.h>
+
+namespace yarp::telemetry::experimental {
+
+/**
+ * @brief A class to represent the Node in Tree struct
+ *
+ */
+template<class T>
+class TreeNode
+{
+public:
+    /**
+     * @brief Construct an empty Node of tree.
+     */
+    TreeNode () = default;
+
+    /**
+     * @brief Construct an empty Node of tree containing a value.
+     *
+     * @param[in] _value An already initialized pointer containing the value stored in the nore
+     */
+    TreeNode(std::shared_ptr<T> _value)
+        : m_value(_value) {
+        assert(m_value);
+    }
+
+    /**
+     * @brief Check if a child with a given name exist
+     *
+     * @param[in] name The name of the child
+     * @return True if the child exist false otherwise.
+     */
+    [[nodiscard]]
+    bool childExists(const std::string& name) const {
+        return m_children.find(name) != m_children.end();
+    }
+
+    /**
+     * @brief Add a new node in the tree. This node will be the child of the this node
+     *
+     * @param[in] name The name of the child
+     * @param[in] node A pointer to the node
+     * @return True if the child has been added, false otherwise.
+     */
+    bool addChild(const std::string& name, std::shared_ptr<TreeNode<T>> node) {
+
+        if(this->childExists(name)) {
+            std::cout << "The TreeNode named " << name << " already exist." << std::endl;
+            return false;
+        }
+
+        if (node == nullptr) {
+            std::cout << "The node should point to an already initialized memory." << std::endl;
+            return false;
+        }
+
+        // insert the new e element in the map
+        const auto out = m_children.insert({name, node});
+        return out.second;
+    }
+
+    /**
+     * @brief Get a child from the node.
+     *
+     * @param[in] name The name of the child.
+     * @return A pointer to TreeNode, if the child is not found the weak pointer cannot be locked.
+     */
+    std::weak_ptr<TreeNode<T>> getChild(const std::string& name) const {
+        if(this->childExists(name)) {
+            return m_children.at(name);
+        }
+
+        return std::make_shared<TreeNode<T>>();
+    }
+
+    /**
+     * @brief Get the value stored in the node.
+     *
+     * @return A pointer to the value stored in the node.
+     */
+    std::shared_ptr<T> getValue() {
+        return m_value;
+    }
+
+    /**
+     * @brief Get the map representing all the children associated to the node.
+     *
+     * @return The map of the children
+     */
+    const std::unordered_map<std::string, std::shared_ptr<TreeNode>>& getChildren() const {
+        return m_children;
+    }
+
+
+    /**
+     * @brief Return a standard text representation of the content of the node.
+     *
+     * @return a string containing the standard text representation of the content of the object.
+     */
+    [[nodiscard]]
+    std::string toString(const std::string& name= ".", const unsigned int depth = 0) const {
+        std::ostringstream oss;
+        for (unsigned int i = 0 ; i < depth ; i++) {
+            if (i != depth-1) {
+                oss <<  "    ";
+            } else {
+                oss <<  "|-- ";
+            }
+        }
+        oss  << name << std::endl;
+        for (const auto & [key, child] : m_children) {
+            oss << child->toString(key, depth + 1);
+        }
+
+        return oss.str();
+    }
+
+    /**
+     * @brief Check if the node is empty
+     *
+     * @return true if a node is empty
+     */
+    [[nodiscard]]
+    bool empty() const {
+        return m_children.empty() && m_value == nullptr;
+    }
+
+    /**
+     * Split a string using the separator
+     *
+     * @param[in] input the stribg that should be split
+     * @return an std::vector containing the substrings
+     */
+    static std::vector<std::string> splitString(const std::string& input) {
+        std::regex re(stringSeparator);
+        std::sregex_token_iterator first{input.begin(), input.end(), re, -1}, last;
+        return {first, last};
+    };
+
+    static std::string stringSeparator; /**< The string separator the default value is :: */
+
+private:
+
+    std::shared_ptr<T> m_value;
+    std::unordered_map<std::string, std::shared_ptr<TreeNode>> m_children;
+};
+
+template<class T>
+std::string TreeNode<T>::stringSeparator = "::";
+
+
+/**
+ * @brief Add a new leaf in the tree
+ *
+ * @param[in] nodes A span representing a list of nodes
+ * @param[in] element The value stored by the leaf
+ * @param[in] treeNode a pointer to a tree node
+ * @return True in case of success false otherwise
+ */
+template<typename T>
+bool addLeaf(matioCpp::Span<const std::string> nodes,
+             std::shared_ptr<T> element,
+             std::shared_ptr<TreeNode<T>> treeNode) {
+
+    assert(nodes.begin() != nodes.end());
+
+    // get the first node in the in nodes
+    const std::string node = *nodes.begin();
+
+    // if the size of the node is equal to 1 means that this is a leaf and so it will contain
+    // the element
+    if(nodes.size() == 1) {
+        if(!treeNode->addChild(node, std::make_shared<TreeNode<T>>(element))) {
+            return false;
+        }
+        return true;
+    }
+
+    // create a new child
+    if (!treeNode->childExists(node)) {
+        if (!treeNode->addChild(node, std::make_shared<TreeNode<T>>())) {
+            return false;
+        }
+    }
+
+    // this is always true since the child has been just added
+    assert(treeNode->getChild(node).lock() != nullptr);
+
+    // propagate the leaf creation to the child
+    return addLeaf(nodes.subspan(1), element, treeNode->getChild(node).lock());
+}
+
+/**
+* @brief Add a new leaf in the tree
+*
+* @param[in] name A string containing the address of the leaf. Use the TreeNode<T>::stringSeparator
+* to define multiple nodes
+* @param[in] element The content of the leaf
+* @param[in] treeNode a pointer to a tree node
+* @return True in case of success false otherwise
+*/
+template<typename  T>
+bool addLeaf(const std::string& name,
+             std::shared_ptr<T> element,
+             std::shared_ptr<TreeNode<T>> treeNode) {
+    // split the string using the separator
+    const std::vector<std::string> nodes = TreeNode<T>::splitString(name);
+
+    // build the leaf
+    return addLeaf(nodes, element, treeNode);
+}
+
+/**
+* @brief Get the leaf from a node.
+*
+* @param[in] nodes A span representing a list of nodes
+* @param[in] treeNode a pointer to a tree node
+* @return A pointer to TreeNode, if the child is not found the weak pointer cannot be locked.
+*/
+template<typename  T>
+std::weak_ptr<TreeNode<T>> getLeaf(matioCpp::Span<const std::string> nodes,
+                                   std::shared_ptr<TreeNode<T>> treeNode) {
+    if (treeNode == nullptr) {
+        return std::make_shared<TreeNode<T>>();
+    }
+
+    // check that the nodes is not an empty span
+    assert(nodes.begin() != nodes.end());
+
+    // get the name of the node
+    const std::string nodeName = *nodes.begin();
+
+    // Try to find the child named nodeName if not found a not lockable weak_ptr is returned
+    auto ptr = treeNode->getChild(nodeName).lock();
+    if (ptr == nullptr) {
+        return std::make_shared<TreeNode<T>>();
+    }
+
+    // if the size of the nodes is equal to one the child is actually the leaf
+    if (nodes.size() == 1) {
+        return ptr;
+    }
+
+    return getLeaf(nodes.subspan(1), ptr);
+}
+
+/**
+* @brief Get the leaf from a node.
+*
+* @param[in] name A string containing the address of the leaf. Use the TreeNode<T>::stringSeparator
+* to define multiple nodes
+* @param[in] treeNode a pointer to a tree node
+* @return A pointer to TreeNode, if the child is not found the weak pointer cannot be locked.
+*/
+template<typename  T>
+std::weak_ptr<TreeNode<T>> getLeaf(const std::string& name,
+                                   std::shared_ptr<TreeNode<T>> treeNode) {
+    const std::vector<std::string> nodes = TreeNode<T>::splitString(name);
+    return getLeaf(nodes, treeNode);
+}
+
+} // yarp::telemetry::experimental
+
+#endif

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -98,6 +98,31 @@ TEST_CASE("Buffer Manager Test")
         }
     }
 
+
+    SECTION("Test nested vector") {
+        // The inputs to the API are defined in the BufferConfig structure
+        yarp::telemetry::experimental::BufferConfig bufferConfig;
+
+        // We use the default config, setting only the number of samples (no auto/periodic saving)
+        bufferConfig.n_samples = n_samples;
+        bufferConfig.channels = { {"struct1::one",{4,1}},
+                                  {"struct1::two",{4,1}},
+                                  {"struct2::one",{4,1}} };
+        bufferConfig.filename = "buffer_manager_test_nested_vector";
+        bufferConfig.auto_save = true;
+
+        yarp::telemetry::experimental::BufferManager<double> bm_v;
+        REQUIRE(bm_v.configure(bufferConfig));
+
+        for (int i = 0; i < 10; i++) {
+            bm_v.push_back({ i+1.0, i+2.0, i+3.0, i+4.0  }, "struct1::one");
+            yarp::os::Time::delay(0.01);
+            bm_v.push_back({ (double)i, i*2.0, i*3.0, i*4.0 }, "struct1::two");
+            yarp::os::Time::delay(0.01);
+            bm_v.push_back({ (double)i, i/2.0, i/3.0, i/4.0 }, "struct2::one");
+        }
+    }
+
     SECTION("Test periodic save") {
 
         yarp::telemetry::experimental::BufferConfig bufferConfig;


### PR DESCRIPTION
This PR implements a new approach to save data in `yarp-telemetry` library. Before entering into the details I want to underline that:
1. This PR is **back-compatible**. The already existing code that uses yarp telemetry still work and the final user will not see any difference in the mat file used to store the data
2. This PR closes https://github.com/robotology/yarp-telemetry/issues/145

As already explained in https://github.com/robotology/yarp-telemetry/issues/145 one of the main limitations of telemetry is the absence of a multilayer structure to store the data. For instance, it would be nice to have all the measurements of the FT contained in the same Matlab structure. Having this goal in mind we can imagine that a `mat` file is just a `tree` containing several structures where each leaf is a `BufferInfo`. The following picture represents the content of a `mat`. The orange circles are the `BufferInfo` (i.e. the leaf of the tree) and the gray one is the intermediate structure.

![image](https://user-images.githubusercontent.com/16744101/146532026-89b3b2b7-c45e-4e15-b60f-98429f13ccd3.png)

In this case, it will be possible to access the element `E2` with the following `Matlab` command
```mat
data = root.A.B.E2;
```

Since we do not want to change the `BufferManager` interface (I want to keep the back compatibility with the already existing code), I decided (discussing with @S-Dafarra and @traversaro) to use a string separator to consider nested struct in the creation of a new channel.
For instance in order to add the element `E2` represented in the above figure the channel has to be defined as follows
```cpp
yarp::telemetry::experimental::ChannelInfo channel{ "root::A::B::E2", {1,1} };
```

This PR contains the implementation of what I have just explained. The main contribution is the introduction of the `TreeNode` class that represents a `node` of the tree. Each node contains a dictionary of childer and a pointer to a `BufferInfo`.

The `BufferManager::m_buffer_map` data struct used to contain the buffer has been substituted by the `std::shared_ptr<TreeNode<BufferInfo<T>>> m_tree` and the buffer manager is in charge to explore the tree to update the content of the `BufferInfo` and save them in a `mat` file.

### TODO:
- [x] Blocked by #144 and  #148  and #152
- [x] Document the code
- [x] Give a complete explanation of the content of the PR in this message

cc @traversaro and @S-Dafarra 