### PR TITLE
Add the possibility to use a different file indexing for the mat files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the possibility to pass `matioCpp::Span` objects to `BufferManager::push_back` and `Record` constructors
 - Added the creation of the dir in the `BufferManager` if the path specified does not exist.
+- Added the `file_indexing` parameter in the `BufferConfig` struct.
 
 ## [0.3.0] - 2021-10-18
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Where the file has to have this format:
         ["two",[1,1]]
     ],
     "enable_compression": true
+    "file_indexing": "%Y_%m_%d_%H_%M_%S"
 }
 ```
 The configuration can be saved **to a json file**

--- a/src/examples/telemetry_buffer_manager_conf_file.cpp
+++ b/src/examples/telemetry_buffer_manager_conf_file.cpp
@@ -23,7 +23,7 @@ using namespace yarp::os;
 constexpr size_t n_samples{20};
 constexpr size_t threshold{10};
 constexpr double check_period{1.0};
-
+constexpr auto file_indexing = "%Y_%m_%d_%H_%M_%S";
 
 
 int main()
@@ -36,6 +36,7 @@ int main()
     bufferConfig.save_period = check_period;
     bufferConfig.data_threshold = threshold;
     bufferConfig.save_periodically = true;
+    bufferConfig.file_indexing = file_indexing;
     std::vector<yarp::telemetry::experimental::ChannelInfo> vars{ { "one",{2,3} },
                                                     { "two",{3,2} } };
     bufferConfig.channels = vars;

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
@@ -36,6 +36,9 @@ struct YARP_telemetry_API BufferConfig {
     bool save_periodically{ false };/**< the flag for enabling the periodic save thread. */
     std::vector<ChannelInfo> channels;/**< the list of pairs representing the channels(variables) */
     bool enable_compression{ false }; /**< the flag for enabling the zlib compression */
+     /** String representing the indexing mode. If the variable is set to `time_since_epoch`, `BufferManager::m_nowFunction`
+      * is used. Othewrise `std::put_time` is used to generate the indexing. https://en.cppreference.com/w/cpp/io/manip/put_time */
+    std::string file_indexing{ "time_since_epoch" };
 };
 
 } // yarp::telemetry::experimental

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
@@ -438,7 +438,7 @@ public:
         matioCpp::Struct timeSeries(m_bufferConfig.filename, signalsVect);
         // and finally we write the file
         // since we might save several files, we need to index them
-        std::string new_file = m_bufferConfig.filename + "_" + std::to_string(m_nowFunction()) + ".mat";
+        std::string new_file = m_bufferConfig.filename + "_" + this->fileIndex() + ".mat";
         if (!m_bufferConfig.path.empty()) {
             new_file = m_bufferConfig.path + new_file;
         }
@@ -480,6 +480,22 @@ private:
                 saveToFile(false);
             }
         }
+    }
+
+    /**
+    * This is an helper function that can be used to generate the file indexing accordingly to the
+    * content of `m_bufferConfig.file_indexing`
+    * @return a string containing the index
+    */
+    std::string fileIndex() const {
+        if (m_bufferConfig.file_indexing == "time_since_epoch") {
+            return std::to_string(m_nowFunction());
+        }
+        std::time_t t = std::time(nullptr);
+        std::tm tm = *std::localtime(&t);
+        std::stringstream time;
+        time << std::put_time(&tm, m_bufferConfig.file_indexing.c_str());
+        return time.str();
     }
 
     /**


### PR DESCRIPTION
With this PR it will be possible to support different methods for file indexing. 


For instance setting
```cpp
config.file_indexing = "%Y_%m_%d_%H_%M_%S";
```

you will get a file named `<file_name>_2021_12_13_19_42_08.mat`

cc @Nicogene @AlexAntn @traversaro @S-Dafarra