### PR TITLE
BufferManager: add dir creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added the possibility to pass `matioCpp::Span` objects to `BufferManager::push_back` and `Record` constructors 
+- Added the possibility to pass `matioCpp::Span` objects to `BufferManager::push_back` and `Record` constructors
+- Added the creation of the dir in the `BufferManager` if the path specified does not exist.
 
 ## [0.3.0] - 2021-10-18
 
 - Added the log of the estimated odometry from `yarp::dev::Nav2D::ILocalization2D`.
-- Deprecated the `logAllQuantities` option in favour of `logControlBoardQuantities`. 
+- Deprecated the `logAllQuantities` option in favour of `logControlBoardQuantities`.
 
 ## [0.2.0] - 2021-05-19
 

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
@@ -38,7 +38,7 @@
 #    include <experimental/filesystem>
      namespace yarp_telemetry_fs = std::experimental::filesystem;
 #  else
-     static_assert(false, "Neither <filesystem> nor <experimental/filesystem> headers are present in the system, but they are required"); 
+     static_assert(false, "Neither <filesystem> nor <experimental/filesystem> headers are present in the system, but they are required");
 #  endif
 #endif
 
@@ -151,8 +151,12 @@ public:
         }
         populateDescriptionCellArray();
         if (!m_bufferConfig.path.empty() && !yarp_telemetry_fs::exists(m_bufferConfig.path)) {
-            std::cout << m_bufferConfig.path << " does not exists." << std::endl;
-            return false;
+            std::error_code ec;
+            auto dir_created = yarp_telemetry_fs::create_directory(m_bufferConfig.path, ec);
+            if (!dir_created) {
+                std::cout << m_bufferConfig.path << " does not exists, and it was not possible to create it." << std::endl;
+                return false;
+            }
         }
         // TODO ROLL BACK IN CASE OF FAILURE
         return ok;


### PR DESCRIPTION
In the previous implementation, if the path did not exist, the configure failed, I think it is more user friendly if the directory is created.

cc @GiulioRomualdi 