### PR TITLE
Add the possibility to specify the saved matfile version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the possibility to pass `matioCpp::Span` objects to `BufferManager::push_back` and `Record` constructors
 - Added the creation of the dir in the `BufferManager` if the path specified does not exist.
 - Added the `file_indexing` parameter in the `BufferConfig` struct.
+- Add the possibility to specify the saved matfile version in the `BufferManager` class. 
 
 ## [0.3.0] - 2021-10-18
 

--- a/README.md
+++ b/README.md
@@ -257,8 +257,9 @@ Where the file has to have this format:
         ["one",[1,1]],
         ["two",[1,1]]
     ],
-    "enable_compression": true
-    "file_indexing": "%Y_%m_%d_%H_%M_%S"
+    "enable_compression": true,
+    "file_indexing": "%Y_%m_%d_%H_%M_%S",
+    "mat_file_version": "v7_3"
 }
 ```
 The configuration can be saved **to a json file**

--- a/src/examples/conf/test_json.json
+++ b/src/examples/conf/test_json.json
@@ -12,5 +12,7 @@
         ["one",[1,1]],
         ["two",[1,1]]
     ],
-    "enable_compression": true
+    "enable_compression": true,
+    "file_indexing": "time_since_epoch",
+    "mat_file_version": "v7_3"
 }

--- a/src/examples/telemetry_buffer_manager_conf_file.cpp
+++ b/src/examples/telemetry_buffer_manager_conf_file.cpp
@@ -7,6 +7,7 @@
  */
 
 
+#include <matioCpp/ForwardDeclarations.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Network.h>
 #include <yarp/telemetry/experimental/BufferManager.h>
@@ -37,6 +38,8 @@ int main()
     bufferConfig.data_threshold = threshold;
     bufferConfig.save_periodically = true;
     bufferConfig.file_indexing = file_indexing;
+    bufferConfig.mat_file_version = matioCpp::FileVersion::MAT7_3;
+
     std::vector<yarp::telemetry::experimental::ChannelInfo> vars{ { "one",{2,3} },
                                                     { "two",{3,2} } };
     bufferConfig.channels = vars;

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.cpp
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.cpp
@@ -11,9 +11,19 @@
 #include <fstream>
 #include <iostream>
 
+namespace matioCpp {
+    NLOHMANN_JSON_SERIALIZE_ENUM( FileVersion, {
+            {FileVersion::Undefined, "undefined"},
+            {FileVersion::MAT4, "v4"},
+            {FileVersion::MAT5, "v5"},
+            {FileVersion::MAT7_3, "v7_3"},
+            {FileVersion::Default, "default"},
+        })
+}
+
 namespace yarp::telemetry::experimental {
     // This expects that the name of the json keyword is the same of the relative variable
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, description_list, path, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels, enable_compression)
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, description_list, path, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels, enable_compression, file_indexing, mat_file_version)
 }
 bool bufferConfigFromJson(yarp::telemetry::experimental::BufferConfig& bufferConfig, const std::string& config_filename) {
     // read a JSON file

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
@@ -9,6 +9,8 @@
 #ifndef YARP_TELEMETRY_BUFFER_CONFIG_H
 #define YARP_TELEMETRY_BUFFER_CONFIG_H
 
+#include <matioCpp/File.h>
+#include <matioCpp/ForwardDeclarations.h>
 #include <yarp/telemetry/experimental/api.h>
 #include <string>
 #include <vector>
@@ -39,6 +41,7 @@ struct YARP_telemetry_API BufferConfig {
      /** String representing the indexing mode. If the variable is set to `time_since_epoch`, `BufferManager::m_nowFunction`
       * is used. Othewrise `std::put_time` is used to generate the indexing. https://en.cppreference.com/w/cpp/io/manip/put_time */
     std::string file_indexing{ "time_since_epoch" };
+    matioCpp::FileVersion mat_file_version{ matioCpp::FileVersion::Default }; /**< Version of the saved matfile.  */
 };
 
 } // yarp::telemetry::experimental

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferManager.h
@@ -442,7 +442,7 @@ public:
         if (!m_bufferConfig.path.empty()) {
             new_file = m_bufferConfig.path + new_file;
         }
-        matioCpp::File file = matioCpp::File::Create(new_file);
+        matioCpp::File file = matioCpp::File::Create(new_file, m_bufferConfig.mat_file_version);
         return file.write(timeSeries, m_bufferConfig.enable_compression ? matioCpp::Compression::zlib : matioCpp::Compression::None);
     }
 


### PR DESCRIPTION
This PR adds the possibility to specify the version of the matfile (see here: https://github.com/ami-iit/matio-cpp/issues/52)
 
If the user does not specify the version the `default` option is used (as before) 

cc @S-Dafarra @Nicogene @traversaro @AlexAntn 