### PR TITLE
Add the possibility to store the elements_names for each channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add `yarp_robot_name` variable in the saved mat file
+- Added the possibility to specify the names of the each element of a channel.
+- BufferInfo is now a struct that contains the name, the dimension and the elements_names.
 
 ## [0.4.0] - 2022-02-22
 
@@ -13,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `file_indexing` parameter in the `BufferConfig` struct.
 - Add the possibility to specify the saved matfile version in the `BufferManager` class. 
 - Added the possibility to have multilayer structures in the `BufferManager`.
-- Add `yarp_robot_name` variable in the saved mat file
 
 ## [0.3.0] - 2021-10-18
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.12)
 project(yarp-telemetry LANGUAGES C CXX
-                       VERSION 0.2.0)
+                       VERSION 0.4.100)
 
 include(GNUInstallDirs)
 include(FeatureSummary)

--- a/README.md
+++ b/README.md
@@ -130,22 +130,21 @@ buffer_manager_test =
 
   struct with fields:
 
-    one: [1×1 struct]
-    two: [1×1 struct]
+    description_list: {[1×0 char]}
+                 two: [1×1 struct]
+                 one: [1×1 struct]
 
 
-buffer_manager_test.one
-
-ans =
+buffer_manager_test.one =
 
   struct with fields:
 
-          data: [1×1×3 int32]
-    dimensions: [1 1 3]
-          name: 'one'
-    timestamps: [523132.9969457 523133.1979436 523133.3988861]
+              data: [1×1×3 int32]
+        dimensions: [1 1 3]
+    elements_names: {'element_0'}
+              name: 'one'
+        timestamps: [1.6481e+09 1.6481e+09 1.6481e+09]
 ```
-
 
 ### Example vector variable
 
@@ -173,8 +172,10 @@ buffer_manager_test_vector =
 
   struct with fields:
 
-    one: [1×1 struct]
-    two: [1×1 struct]
+    description_list: {[1×0 char]}
+                 two: [1×1 struct]
+                 one: [1×1 struct]
+
 
 >> buffer_manager_test_vector.one
 
@@ -182,11 +183,30 @@ ans =
 
   struct with fields:
 
-          data: [4×1×3 double]
-    dimensions: [4 1 3]
-          name: 'one'
-    timestamps: [523135.0186688 523135.219639 523135.4203739]
+              data: [4×1×3 double]
+        dimensions: [4 1 3]
+    elements_names: {4×1 cell}
+              name: 'one'
+        timestamps: [1.6481e+09 1.6481e+09 1.6481e+09]
+
+
+>> buffer_manager_test_vector.one.elements_names
+
+ans =
+
+  4×1 cell array
+
+    {'element_0'}
+    {'element_1'}
+    {'element_2'}
+    {'element_3'}
 ```
+
+It is also possible to specify the name of the elements of each variable with
+```c++
+yarp::telemetry::experimental::ChannelInfo var_one{ "one", {4,1}, {"A", "B", "C", "D"}};
+```
+
 
 ### Example matrix variable
 
@@ -295,22 +315,32 @@ It is possible to load the configuration of a BufferManager **from a json file**
 Where the file has to have this format:
 ```json
 {
-    "description_list": ["This is a test",
-                         "Or it isn't?"],
-    "path":"/my/preferred/path",
-    "filename": "buffer_manager_test_conf_file",
-    "n_samples": 20,
-    "save_period": 1.0,
-    "data_threshold": 10,
-    "auto_save": true,
-    "save_periodically": true,
-    "channels": [
-        ["one",[1,1]],
-        ["two",[1,1]]
-    ],
-    "enable_compression": true,
-    "file_indexing": "%Y_%m_%d_%H_%M_%S",
-    "mat_file_version": "v7_3"
+  "description_list": [
+    "This is a test",
+    "Or it isn't?"
+  ],
+  "path":"/my/preferred/path",
+  "filename": "buffer_manager_test_conf_file",
+  "n_samples": 20,
+  "save_period": 1.0,
+  "data_threshold": 10,
+  "auto_save": true,
+  "save_periodically": true,
+  "channels": [
+    {
+      "dimensions": [1,1],
+      "elements_names": ["element_0"],
+      "name": "one"
+    },
+    {
+      "dimensions": [1,1],
+      "elements_names": ["element_0"],
+      "name": "two"
+    }
+  ],
+  "enable_compression": true,
+  "file_indexing": "%Y_%m_%d_%H_%M_%S",
+  "mat_file_version": "v7_3"
 }
 ```
 The configuration can be saved **to a json file**

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ It is possible to load the configuration of a BufferManager **from a json file**
 Where the file has to have this format:
 ```json
 {
+  "yarp_robot_name": "robot",
   "description_list": [
     "This is a test",
     "Or it isn't?"

--- a/src/examples/conf/test_json.json
+++ b/src/examples/conf/test_json.json
@@ -1,19 +1,29 @@
 {
-    "yarp_robot_name":"robot",
-    "description_list": ["This is a test",
-                         "Or it isn't?"],
-    "path":"",
-    "filename": "buffer_manager_test_conf_file",
-    "n_samples": 20,
-    "save_period": 1.0,
-    "data_threshold": 10,
-    "auto_save": true,
-    "save_periodically": true,
-    "channels": [
-        ["one",[1,1]],
-        ["two",[1,1]]
-    ],
-    "enable_compression": true,
-    "file_indexing": "time_since_epoch",
-    "mat_file_version": "v7_3"
+  "yarp_robot_name":"robot",
+  "description_list": [
+    "This is a test",
+    "Or it isn't?"
+  ],
+  "path": "",
+  "filename": "buffer_manager_test_conf_file",
+  "n_samples": 20,
+  "save_period": 1.0,
+  "data_threshold": 10,
+  "auto_save": true,
+  "save_periodically": true,
+  "channels": [
+    {
+      "dimensions": [1,1],
+      "elements_names": ["element_0"],
+      "name": "one"
+    },
+    {
+      "dimensions": [1,1],
+      "elements_names": ["element_0"],
+      "name": "two"
+    }
+  ],
+  "enable_compression": true,
+  "file_indexing": "time_since_epoch",
+  "mat_file_version": "v7_3"
 }

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.cpp
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.cpp
@@ -22,6 +22,55 @@ namespace matioCpp {
 }
 
 namespace yarp::telemetry::experimental {
+
+    ChannelInfo::ChannelInfo(const std::string& name,
+                             const dimensions_t& dimensions,
+                             const elements_names_t& elements_names)
+        : name(name),
+          dimensions(dimensions),
+          elements_names(elements_names)
+    {
+        const unsigned int elements = std::accumulate(dimensions.begin(),
+                                                      dimensions.end(),
+                                                      1,
+                                                      std::multiplies<>());
+
+        if(elements != elements_names.size()) {
+            std::cout << "[ChannelInfo::ChannelInfo] The size of the vector elements_names is "
+                      << "different from the expected one. Expected: " << elements
+                      << "Passed: " << elements_names.size() << std::endl;
+        }
+    }
+
+    ChannelInfo::ChannelInfo(const std::string& name, const dimensions_t& dimensions)
+        : name(name),
+          dimensions(dimensions)
+    {
+        const unsigned int elements = std::accumulate(dimensions.begin(),
+                                                dimensions.end(),
+                                                1,
+                                                std::multiplies<>());
+
+        for (unsigned int i = 0; i < elements; i++) {
+            elements_names.push_back("element_" + std::to_string(i));
+        }
+    }
+
+    void to_json(nlohmann::json& j, const ChannelInfo& info)
+    {
+        j = nlohmann::json{{"name", info.name},
+                           {"dimensions", info.dimensions},
+                           {"elements_names", info.elements_names},
+                };
+    }
+
+    void from_json(const nlohmann::json& j, ChannelInfo& info)
+    {
+        j.at("name").get_to(info.name);
+        j.at("dimensions").get_to(info.dimensions);
+        j.at("elements_names").get_to(info.elements_names);
+    }
+
     // This expects that the name of the json keyword is the same of the relative variable
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(BufferConfig, yarp_robot_name, description_list, path, filename, n_samples, save_period, data_threshold, auto_save, save_periodically, channels, enable_compression, file_indexing, mat_file_version)
 }

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
@@ -14,14 +14,28 @@
 #include <yarp/telemetry/experimental/api.h>
 #include <string>
 #include <vector>
+#include <numeric>
 
 namespace yarp::telemetry::experimental {
 using dimensions_t = std::vector<size_t>;
+using elements_names_t = std::vector<std::string>;
 /**
  * @brief Pair representing a channel(variable) in terms of
  * name and dimensions.
  */
-using ChannelInfo = std::pair< std::string, dimensions_t >;
+struct ChannelInfo {
+    std::string name;
+    dimensions_t dimensions;
+    elements_names_t elements_names;
+
+    ChannelInfo() = default;
+
+    ChannelInfo(const std::string& name,
+                const dimensions_t& dimensions,
+                const elements_names_t& elements_names);
+
+    ChannelInfo(const std::string& name, const dimensions_t& dimensions);
+};
 
 /**
  * @brief Struct containing the parameters for configuring a yarp::telemetry::experimental::BufferManager.

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
@@ -23,7 +23,7 @@ using elements_names_t = std::vector<std::string>;
  * @brief Struct representing a channel(variable) in terms of
  * name and dimensions and names of the each element of a variable.
  */
-struct ChannelInfo {
+struct YARP_telemetry_API ChannelInfo {
     std::string name; /**< Name of the channel */
     dimensions_t dimensions; /**< Dimension of the channel */
     elements_names_t elements_names; /**< Vector containing the names of each element of the channel */

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
@@ -20,20 +20,38 @@ namespace yarp::telemetry::experimental {
 using dimensions_t = std::vector<size_t>;
 using elements_names_t = std::vector<std::string>;
 /**
- * @brief Pair representing a channel(variable) in terms of
- * name and dimensions.
+ * @brief Struct representing a channel(variable) in terms of
+ * name and dimensions and names of the each element of a variable.
  */
 struct ChannelInfo {
-    std::string name;
-    dimensions_t dimensions;
-    elements_names_t elements_names;
+    std::string name; /**< Name of the channel */
+    dimensions_t dimensions; /**< Dimension of the channel */
+    elements_names_t elements_names; /**< Vector containing the names of each element of the channel */
 
+    /**
+     * @brief Default constructor
+     */
     ChannelInfo() = default;
 
+    /**
+     * @brief Construct a ChannelInfo from name, dimensions and a vector containing the name of
+     * the elements associated to the channel.
+     * @param name name of the channel.
+     * @param dimensions dimension associated to the channel.
+     * @param elements_names Vector containing the names of each element of the channel.
+     */
     ChannelInfo(const std::string& name,
                 const dimensions_t& dimensions,
                 const elements_names_t& elements_names);
 
+    /**
+     * @brief Construct a ChannelInfo from name and dimensions.
+     * @param name name of the channel.
+     * @param dimensions dimension associated to the channel.
+     * @note If the constructor is called the elements_names are set as
+     * elements_names = [element_0, element_1, ..., element_n], where n is given by the
+     * product of the dimensions.
+     */
     ChannelInfo(const std::string& name, const dimensions_t& dimensions);
 };
 

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -98,6 +98,26 @@ TEST_CASE("Buffer Manager Test")
         }
     }
 
+    SECTION("Test vector with elements names") {
+        // The inputs to the API are defined in the BufferConfig structure
+        yarp::telemetry::experimental::BufferConfig bufferConfig;
+
+        // We use the default config, setting only the number of samples (no auto/periodic saving)
+        bufferConfig.n_samples = n_samples;
+        bufferConfig.channels = { {"one", {4,1}, {"e0", "e1", "e2", "e3"}},
+                                  {"two", {4,1}, {"v0", "v1", "v2", "v3"}} };
+        bufferConfig.filename = "buffer_manager_test_vector";
+        bufferConfig.auto_save = true;
+
+        yarp::telemetry::experimental::BufferManager<double> bm_v;
+        REQUIRE(bm_v.configure(bufferConfig));
+
+        for (int i = 0; i < 10; i++) {
+            bm_v.push_back({ i + 1.0, i + 2.0, i + 3.0, i + 4.0 }, "one");
+            yarp::os::Time::delay(0.01);
+            bm_v.push_back({ (double)i, i * 2.0, i * 3.0, i * 4.0 }, "two");
+        }
+    }
 
     SECTION("Test nested vector") {
         // The inputs to the API are defined in the BufferConfig structure

--- a/test/BufferManagerTest.cpp
+++ b/test/BufferManagerTest.cpp
@@ -176,10 +176,10 @@ TEST_CASE("Buffer Manager Test")
         REQUIRE(bufferConfig.data_threshold == 10);
         REQUIRE(bufferConfig.save_periodically == true);
         REQUIRE(bufferConfig.channels.size() == 2);
-        REQUIRE(bufferConfig.channels[0].first == "one");
-        REQUIRE(bufferConfig.channels[0].second == std::vector<size_t>{1, 1});
-        REQUIRE(bufferConfig.channels[1].first == "two");
-        REQUIRE(bufferConfig.channels[1].second == std::vector<size_t>{1, 1});
+        REQUIRE(bufferConfig.channels[0].name == "one");
+        REQUIRE(bufferConfig.channels[0].dimensions == std::vector<size_t>{1, 1});
+        REQUIRE(bufferConfig.channels[1].name == "two");
+        REQUIRE(bufferConfig.channels[1].dimensions == std::vector<size_t>{1, 1});
         REQUIRE(bufferConfig.enable_compression == true);
 
         REQUIRE(bm.configure(bufferConfig));


### PR DESCRIPTION
This PR adds a new entry for each stored variable called `elements_names`. The entry is a cell that will contain the name of each element of a variable. 

BufferInfo is now a struct that contains the `name`, the `dimension`, and the `elements_names`.


cc @traversaro @S-Dafarra @Nicogene @AlexAntn 