### PR TITLE
Fixed bug preventing the save of files when multiple channels are empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the possibility to specify the names of the each element of a channel.
 - BufferInfo is now a struct that contains the name, the dimension and the elements_names.
 - Added the possibility to have channels with different types (including custom structs) in a single ``BufferManager``.
+- Fixed a bug preventing a log file to be saved when multiple channels are empty.
 
 ## [0.4.0] - 2022-02-22
 

--- a/src/examples/telemetry_buffer_manager_conf_file.cpp
+++ b/src/examples/telemetry_buffer_manager_conf_file.cpp
@@ -33,6 +33,7 @@ int main()
     yarp::telemetry::experimental::BufferConfig bufferConfig;
 
     // we configure our API to use our periodic saving option
+    bufferConfig.filename = "test_json_write";
     bufferConfig.n_samples = n_samples;
     bufferConfig.save_period = check_period;
     bufferConfig.data_threshold = threshold;
@@ -53,7 +54,7 @@ int main()
 
     yarp::telemetry::experimental::BufferManager<int32_t> bm;
 
-    ok = bufferConfigFromJson(bufferConfig,"test_json.json");
+    ok = bufferConfigFromJson(bufferConfig,"test_json_write.json");
 
     ok = ok && bm.configure(bufferConfig);
 

--- a/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
+++ b/src/libYARP_telemetry/src/yarp/telemetry/experimental/BufferConfig.h
@@ -63,7 +63,7 @@ struct YARP_telemetry_API BufferConfig {
     std::string yarp_robot_name{""}; /** < The yarp robot name associated to the machine where the logger runs */
     std::vector<std::string> description_list{""}; /** < the description list, e.g. it can contain the axes names that are logged*/
     std::string path{ "" }; /**< the path in which the files will be saved. */
-    std::string filename{ "" };/**< the file name, to it will be appended the suffix "_<timestamp>.mat". */
+    std::string filename{ "yarp_telemetry_log" };/**< the file name, to it will be appended the suffix "_<timestamp>.mat". */
     size_t n_samples{ 0 };/**< the max number of samples contained in the buffer/s */
     double save_period{ 0.010 };/**< the period in sec of the save thread */
     size_t data_threshold{ 0 };/**< the save thread saves to a file if there are at least data_threshold samples */


### PR DESCRIPTION
I just noticed that since https://github.com/robotology/yarp-telemetry/pull/146, when running the example ``telemetry_buffer_manager_conf_file_example``, we have the following output

```
==13014== 
==13014== HEAP SUMMARY:
==13014==     in use at exit: 0 bytes in 0 blocks
==13014==   total heap usage: 62 allocs, 62 frees, 104,173 bytes allocated
==13014== 
==13014== All heap blocks were freed -- no leaks are possible
==13014== 
==13014== For lists of detected and suppressed errors, rerun with: -s
==13014== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==13019== Memcheck, a memory error detector
==13019== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13019== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==13019== Command: ./telemetry_buffer_manager_conf_file_example
==13019== 
Starting loop
two does not contain data, skipping
two does not contain data, skipping
one does not contain data, skipping
HDF5-DIAG: Error detected in HDF5 (1.10.4) thread 110835456:
  #000: ../../../src/H5G.c line 323 in H5Gcreate2(): unable to create group
    major: Symbol table
    minor: Unable to initialize object
  #001: ../../../src/H5Gint.c line 157 in H5G__create_named(): unable to create and link to group
    major: Symbol table
    minor: Unable to initialize object
  #002: ../../../src/H5L.c line 1572 in H5L_link_object(): unable to create new link to object
    major: Links
    minor: Unable to initialize object
  #003: ../../../src/H5L.c line 1813 in H5L__create_real(): can't insert link
    major: Links
    minor: Unable to insert object
  #004: ../../../src/H5Gtraverse.c line 851 in H5G_traverse(): internal path traversal failed
    major: Symbol table
    minor: Object not found
  #005: ../../../src/H5Gtraverse.c line 627 in H5G__traverse_real(): traversal operator failed
    major: Symbol table
    minor: Callback failed
  #006: ../../../src/H5L.c line 1608 in H5L__link_cb(): name already exists
    major: Links
    minor: Object already exists
Error: [matioCpp::File::write] Failed to write the variable to the file.
two does not contain data, skipping
one does not contain data, skipping
HDF5-DIAG: Error detected in HDF5 (1.10.4) thread 89835392:
  #000: ../../../src/H5G.c line 323 in H5Gcreate2(): unable to create group
    major: Symbol table
    minor: Unable to initialize object
  #001: ../../../src/H5Gint.c line 157 in H5G__create_named(): unable to create and link to group
    major: Symbol table
    minor: Unable to initialize object
  #002: ../../../src/H5L.c line 1572 in H5L_link_object(): unable to create new link to object
    major: Links
    minor: Unable to initialize object
  #003: ../../../src/H5L.c line 1813 in H5L__create_real(): can't insert link
    major: Links
    minor: Unable to insert object
  #004: ../../../src/H5Gtraverse.c line 851 in H5G_traverse(): internal path traversal failed
    major: Symbol table
    minor: Object not found
  #005: ../../../src/H5Gtraverse.c line 627 in H5G__traverse_real(): traversal operator failed
    major: Symbol table
    minor: Callback failed
  #006: ../../../src/H5L.c line 1608 in H5L__link_cb(): name already exists
    major: Links
    minor: Object already exists
Error: [matioCpp::File::write] Failed to write the variable to the file.
==13019== 
==13019== HEAP SUMMARY:
==13019==     in use at exit: 1,864 bytes in 3 blocks
==13019==   total heap usage: 8,2[95](https://github.com/robotology/yarp-telemetry/runs/5738646897?check_suite_focus=true#step:17:95) allocs, 8,292 frees, 6,874,213 bytes allocated
==13019== 
==[130](https://github.com/robotology/yarp-telemetry/runs/5738646897?check_suite_focus=true#step:17:130)19== LEAK SUMMARY:
==13019==    definitely lost: 0 bytes in 0 blocks
==13019==    indirectly lost: 0 bytes in 0 blocks
==13019==      possibly lost: 0 bytes in 0 blocks
==13019==    still reachable: 1,864 bytes in 3 blocks
==13019==         suppressed: 0 bytes in 0 blocks
==13019== Reachable blocks (those to which a pointer was found) are not shown.
==13019== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==13019== 
==13019== For lists of detected and suppressed errors, rerun with: -s
==13019== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Digging a bit into that error, it turned out that it was due to the fact that the ``Struct`` we were trying to save in the file was having two fields with the same name ``unnamed_struct``. This was due to the logic of ``createElementStruct`` returning an empty ``Struct`` when a channel is empty. The problem is that if two channels are empty, the struct appears to have two fields with the same name, causing issues when saving.

I took the occasion also to add a bunch of checks to make sure that the saving is successfull.